### PR TITLE
GH-6169 catch errors, improve types, add FN_README

### DIFF
--- a/FN_README.md
+++ b/FN_README.md
@@ -1,0 +1,26 @@
+
+# Troubleshooting
+
+## "Cannot find module" typescript errors (ts2307)
+
+Smart IDEs (such as VSCode or IntelliJ) require special configuration for TypeScript to work when using Plug'n'Play installs.
+A collection of settings for each editor can be found under the (link)[https://yarnpkg.com/getting-started/editor-sdks#vscode]
+
+Generally speaking: the editor SDKs and settings can be generated using `yarn dlx @yarnpkg/sdks` (or yarn sdks if you added @yarnpkg/sdks to your dependencies):
+- Use yarn sdks vscode vim to generate both the base SDKs and the settings for the specified supported editors.
+- Use yarn sdks base to generate the base SDKs and then manually tweak the configuration of unsupported editors.
+- Use yarn sdks to update all installed SDKs and editor settings.
+
+
+### VSCode
+
+To support features like go-to-definition a plugin like ZipFS is needed.
+
+Run the following command, which will generate a new directory called .yarn/sdks:
+`yarn dlx @yarnpkg/sdks vscode`
+
+For safety reason VSCode requires you to explicitly activate the custom TS settings:
+
+- Press ctrl+shift+p in a TypeScript file
+- Choose "Select TypeScript Version"
+- Pick "Use Workspace Version"

--- a/packages/grafana-runtime/src/services/LocationService.ts
+++ b/packages/grafana-runtime/src/services/LocationService.ts
@@ -47,7 +47,7 @@ export class HistoryWrapper implements LocationService {
     this.getLocation = this.getLocation.bind(this);
   }
 
-  fnPathnameChange(path: string, queryParams: string) {
+  fnPathnameChange(path: string, queryParams: any) {
     this.history.location.pathname = path;
     this.history.location.search = urlUtil.toUrlParams(queryParams);
   }
@@ -91,6 +91,7 @@ export class HistoryWrapper implements LocationService {
   }
 
   reload() {
+    /* eslint-disable-next-line  */
     const prevState = (this.history.location.state as any)?.routeReloadCounter;
     this.history.replace({
       ...this.history.location,

--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -35,7 +35,7 @@ type CommonProps = {
   isHighlighted?: boolean;
 };
 
-export type ToolbarButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement>;
+export type ToolbarButtonProps = CommonProps & ButtonHTMLAttributes<HTMLButtonElement> & { isHidden?: boolean };
 
 export type ToolbarButtonVariant = 'default' | 'primary' | 'destructive' | 'active';
 

--- a/public/app/core/components/Page/usePageTitle.ts
+++ b/public/app/core/components/Page/usePageTitle.ts
@@ -2,11 +2,13 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
 import { NavModel, NavModelItem } from '@grafana/data';
+import { FnGlobalState } from 'app/core/reducers/fn-slice';
+import type { StoreState } from 'app/types';
 
 import { Branding } from '../Branding/Branding';
 
 export function usePageTitle(navModel?: NavModel, pageNav?: NavModelItem) {
-  const { FNDashboard, pageTitle } = useSelector((state) => state.fnGlobleState);
+  const { FNDashboard, pageTitle } = useSelector<StoreState, FnGlobalState>((state) => state.fnGlobalState);
   useEffect(() => {
     const parts: string[] = [];
 

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -34,7 +34,10 @@ const fnSlice = createSlice({
         ...action.payload,
       };
     },
-    updateFnState: (state, action: PayloadAction<{ type: string; payload: string | boolean | HTMLElement }>) => {
+    updateFnState: (
+      state,
+      action: PayloadAction<{ type: keyof FnGlobalState; payload: FnGlobalState[keyof FnGlobalState] }>
+    ) => {
       const { type, payload } = action.payload;
       return {
         ...state,

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -1,32 +1,34 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-interface FNState {
+import { GrafanaThemeType } from '@grafana/data';
+
+export interface FnGlobalState {
   FNDashboard: boolean;
   uid: string;
   slug: string;
-  theme: string;
-  controlsContainer: HTMLElement | undefined;
+  theme: GrafanaThemeType;
+  controlsContainer: HTMLElement | null | undefined;
   pageTitle: string;
   queryParams: object;
   hiddenVariables: string[];
 }
 
-const initialState: FNState = {
+const initialState: FnGlobalState = {
   FNDashboard: false,
   uid: '',
   slug: '',
-  theme: '',
-  controlsContainer: undefined,
+  theme: GrafanaThemeType.Light,
+  controlsContainer: null,
   pageTitle: '',
   queryParams: {},
   hiddenVariables: [],
 };
 
 const fnSlice = createSlice({
-  name: 'fnGlobleState',
+  name: 'fnGlobalState',
   initialState,
   reducers: {
-    setIntialMountState: (state, action: PayloadAction<FNState>) => {
+    setInitialMountState: (state, action: PayloadAction<FnGlobalState>) => {
       return {
         ...state,
         ...action.payload,
@@ -42,5 +44,5 @@ const fnSlice = createSlice({
   },
 });
 
-export const { updateFnState, setIntialMountState } = fnSlice.actions;
+export const { updateFnState, setInitialMountState } = fnSlice.actions;
 export const fnSliceReducer = fnSlice.reducer;

--- a/public/app/core/reducers/index.ts
+++ b/public/app/core/reducers/index.ts
@@ -1,5 +1,5 @@
 import { appNotificationsReducer as appNotifications } from './appNotification';
-import { fnSliceReducer as fnGlobleState } from './fn-slice';
+import { fnSliceReducer as fnGlobalState } from './fn-slice';
 import { navTreeReducer as navBarTree } from './navBarTree';
 import { navIndexReducer as navIndex } from './navModel';
 
@@ -7,5 +7,5 @@ export default {
   navBarTree,
   navIndex,
   appNotifications,
-  fnGlobleState,
+  fnGlobalState,
 };

--- a/public/app/features/alerting/unified/mocks.ts
+++ b/public/app/features/alerting/unified/mocks.ts
@@ -524,7 +524,7 @@ export function mockStore(recipe: (state: StoreState) => Promise<StoreState> | v
   const defaultState = configureStore().getState() as PreloadedState<StoreState>;
 
   return configureStore(
-    /* eslint-disable-next-line  */
+    // @ts-ignore
     produce(defaultState, recipe as (state: StoreState) => Promise<StoreState>) as Promise<
       Required<PreloadedState<StoreState>>
     >

--- a/public/app/features/dashboard/components/DashNav/DashNav.tsx
+++ b/public/app/features/dashboard/components/DashNav/DashNav.tsx
@@ -1,9 +1,8 @@
 import { t, Trans } from '@lingui/macro';
 import React, { FC, ReactNode } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { useLocation } from 'react-router-dom';
 
-import { locationUtil, textUtil } from '@grafana/data';
+import { textUtil } from '@grafana/data';
 // import { textUtil } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
 import { locationService } from '@grafana/runtime';
@@ -32,7 +31,7 @@ const mapDispatchToProps = {
 };
 
 const mapStateToProps = (state: StoreState) => {
-  return { ...state.fnGlobleState };
+  return { ...state.fnGlobalState };
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -315,7 +314,7 @@ export const DashNav = React.memo<Props>((props) => {
     window.location.href = textUtil.sanitizeUrl(snapshotUrl);
   };
 
-  const { isFullscreen, title, folderTitle, kioskMode } = props;
+  const { isFullscreen, title, folderTitle } = props;
 
   // let titleHref = '';
   // let parentHref = '';

--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -18,6 +18,7 @@ interface OwnProps {
   dashboard: DashboardModel;
   links: DashboardLink[];
   annotations: AnnotationQuery[];
+  hiddenVariables?: string[];
 }
 
 interface ConnectedProps {
@@ -26,7 +27,7 @@ interface ConnectedProps {
 
 interface DispatchProps {}
 
-type Props = OwnProps & ConnectedProps & DispatchProps & { hiddenVariables: string[] };
+type Props = OwnProps & ConnectedProps & DispatchProps;
 
 class SubMenuUnConnected extends PureComponent<Props> {
   onAnnotationStateChanged = (updatedAnnotation: any) => {

--- a/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
@@ -8,7 +8,7 @@ import { VariableHide, VariableModel } from '../../../variables/types';
 interface Props {
   variables: VariableModel[];
   readOnly?: boolean;
-  hiddenVariables: string[];
+  hiddenVariables?: string[];
 }
 
 export const SubMenuItems: FunctionComponent<Props> = ({ variables, readOnly, hiddenVariables }) => {

--- a/public/app/features/dashboard/containers/DashboardPage.tsx
+++ b/public/app/features/dashboard/containers/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames';
 import React, { PureComponent } from 'react';
 import ReactDOM from 'react-dom';
-import { connect, ConnectedProps } from 'react-redux';
+import { connect, ConnectedProps, MapDispatchToProps, MapStateToProps } from 'react-redux';
 
 import { locationUtil, NavModelItem, TimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -16,7 +16,7 @@ import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { DashboardModel, PanelModel } from 'app/features/dashboard/state';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { getPageNavFromSlug, getRootContentNavModel } from 'app/features/storage/StorageFolderPage';
-import { DashboardRoutes, KioskMode, StoreState } from 'app/types';
+import { DashboardRoutes, DashboardState, KioskMode, StoreState } from 'app/types';
 import { PanelEditEnteredEvent, PanelEditExitedEvent } from 'app/types/events';
 
 import { cancelVariables, templateVarsChangedInUrl } from '../../variables/state/actions';
@@ -55,13 +55,29 @@ export type DashboardPageRouteSearchParams = {
   refresh?: string;
 };
 
-export const mapStateToProps = (state: StoreState) => ({
+export type MapStateToDashboardPageProps = MapStateToProps<
+  Pick<DashboardState, 'initPhase' | 'initError'> & { dashboard: ReturnType<DashboardState['getModel']> },
+  OwnProps,
+  StoreState
+>;
+
+export type MapDispatchToDashboardPageProps = MapDispatchToProps<MappedDispatch, OwnProps>;
+
+export type MappedDispatch = {
+  initDashboard: typeof initDashboard;
+  cleanUpDashboardAndVariables: typeof cleanUpDashboardAndVariables;
+  notifyApp: typeof notifyApp;
+  cancelVariables: typeof cancelVariables;
+  templateVarsChangedInUrl: typeof templateVarsChangedInUrl;
+};
+
+export const mapStateToProps: MapStateToDashboardPageProps = (state) => ({
   initPhase: state.dashboard.initPhase,
   initError: state.dashboard.initError,
   dashboard: state.dashboard.getModel(),
 });
 
-const mapDispatchToProps = {
+const mapDispatchToProps: MapDispatchToDashboardPageProps = {
   initDashboard,
   cleanUpDashboardAndVariables,
   notifyApp,
@@ -74,13 +90,14 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type OwnProps = {
   isPublic?: boolean;
   isFNDashboard?: boolean;
-  controlsContainer: HTMLElement;
+  controlsContainer?: HTMLElement | null;
+  hiddenVariables?: string[];
 };
 
 export type Props = OwnProps &
   Themeable2 &
   GrafanaRouteComponentProps<DashboardPageRouteParams, DashboardPageRouteSearchParams> &
-  ConnectedProps<typeof connector> & { hiddenVariables: string[] };
+  ConnectedProps<typeof connector>;
 
 export interface State {
   editPanel: PanelModel | null;
@@ -126,7 +143,7 @@ export class UnthemedDashboardPage extends PureComponent<Props, State> {
   }
 
   initDashboard() {
-    const { dashboard, isPublic, isFNDashboard, match, queryParams, hiddenVariables } = this.props;
+    const { dashboard, isPublic, isFNDashboard, match, queryParams } = this.props;
 
     if (dashboard) {
       this.closeDashboard();

--- a/public/app/features/dashboard/dashgrid/PanelChrome.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelChrome.tsx
@@ -54,6 +54,7 @@ export interface Props {
   width: number;
   height: number;
   onInstanceStateChange: (value: any) => void;
+  FNDashboard?: boolean;
 }
 
 export interface State {
@@ -504,7 +505,7 @@ class PanelChromeUnconnected extends PureComponent<Props, State> {
   }
 
   render() {
-    const { dashboard, panel, isViewing, isEditing, width, height, plugin, FNDashboard, slug } = this.props;
+    const { dashboard, panel, isViewing, isEditing, width, height, plugin, FNDashboard } = this.props;
     const { errorMessage, data } = this.state;
     const { transparent } = panel;
 
@@ -565,7 +566,7 @@ class PanelChromeUnconnected extends PureComponent<Props, State> {
 }
 
 const mapStateToProps = (state: StoreState) => {
-  return { ...state.fnGlobleState };
+  return { ...state.fnGlobalState };
 };
 const connector = connect(mapStateToProps);
 export const PanelChrome = connector(PanelChromeUnconnected);

--- a/public/app/features/dashboard/dashgrid/liveTimer.ts
+++ b/public/app/features/dashboard/dashgrid/liveTimer.ts
@@ -1,11 +1,14 @@
+import { ClassicComponentClass } from 'react';
 import { BehaviorSubject } from 'rxjs';
 
 import { dateMath, dateTime, TimeRange } from '@grafana/data';
 
-import { PanelChrome } from './PanelChrome';
+import { Props } from './PanelChrome';
 
 // target is 20hz (50ms), but we poll at 100ms to smooth out jitter
 const interval = 100;
+
+type PanelChrome = InstanceType<ClassicComponentClass<Props>> & { liveTimeChanged: (tr: TimeRange) => void };
 
 interface LiveListener {
   last: number;

--- a/public/app/features/variables/pickers/PickerRenderer.tsx
+++ b/public/app/features/variables/pickers/PickerRenderer.tsx
@@ -3,7 +3,10 @@ import { useSelector } from 'react-redux';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Tooltip } from '@grafana/ui';
+import { FnGlobalState } from 'app/core/reducers/fn-slice';
+import type { StoreState } from 'app/types';
 
+import { GrafanaThemeType } from '../../../../../packages/grafana-data/src/types/theme';
 import { variableAdapters } from '../adapters';
 import { VariableHide, VariableModel } from '../types';
 
@@ -12,8 +15,8 @@ interface Props {
   readOnly?: boolean;
 }
 
-const changeLabelStyle = (theme: string) => {
-  if (theme === 'light') {
+const changeLabelStyle = (theme: GrafanaThemeType) => {
+  if (theme === GrafanaThemeType.Light) {
     return { color: '#2D333E' };
   }
   return { color: '#fff' };
@@ -38,7 +41,7 @@ export const PickerRenderer: FunctionComponent<Props> = (props) => {
 
 function PickerLabel({ variable }: PropsWithChildren<Props>): ReactElement | null {
   const labelOrName = useMemo(() => variable.label || variable.name, [variable]);
-  const { FNDashboard, theme } = useSelector((state) => state.fnGlobleState);
+  const { FNDashboard, theme } = useSelector<StoreState, FnGlobalState>((state) => state.fnGlobalState);
   if (variable.hide !== VariableHide.dontHide) {
     return null;
   }

--- a/public/app/fn-app/fn-app-provider.tsx
+++ b/public/app/fn-app/fn-app-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, FC,  } from 'react';
 import { Provider } from 'react-redux';
 
 import { config, navigationLogger } from '@grafana/runtime';
@@ -11,12 +11,13 @@ import { LiveConnectionWarning } from 'app/features/live/LiveConnectionWarning';
 import { store } from 'app/store/store';
 
 import app from '../fn_app';
+import { FNDashboardProps } from './types';
 
-interface FnAppProviderProps {
-  fnError: React.FunctionComponent;
-}
+type FnAppProviderProps  = Pick<FNDashboardProps, 'fnError'>;
 
-export const FnAppProvider: React.Component<FnAppProviderProps> = ({ children, FnError }) => {
+export const FnAppProvider: FC<FnAppProviderProps> = (props) => {
+  const { children, fnError = null } = props;
+
   const [ready, setReady] = useState(false);
   navigationLogger('AppWrapper', false, 'rendering');
   useEffect(() => {
@@ -30,12 +31,19 @@ export const FnAppProvider: React.Component<FnAppProviderProps> = ({ children, F
   }, []);
 
   if (!ready) {
-    return <>{FnError}</>;
+    /**
+     * TODO: I think loader would be better
+     */
+    return <>{fnError}</>;
   }
 
   if (!store) {
-    return <>{FnError}</>;
+    /**
+     * TODO: I think loader would be better
+     */
+    return <>{fnError}</>;
   }
+
   return (
     <Provider store={store}>
       <I18nProvider>

--- a/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
@@ -1,6 +1,4 @@
-import React, { ComponentType } from 'react';
-
-import { store } from 'app/store/store';
+import React, { ComponentType, FC } from 'react';
 
 import { AngularRoot } from '../../angular/AngularRoot';
 import { FnAppProvider } from '../fn-app-provider';
@@ -17,8 +15,8 @@ import { RenderFNDashboard } from './render-fn-dashboard';
 // import { DashboardRoutes } from '../types';
 
 /** Used by enterprise */
-let bodyRenderHooks: ComponentType[] = [];
-let pageBanners: ComponentType[] = [];
+const bodyRenderHooks: ComponentType[] = [];
+const pageBanners: ComponentType[] = [];
 
 export function addBodyRenderHook(fn: ComponentType) {
   bodyRenderHooks.push(fn);
@@ -28,9 +26,9 @@ export function addPageBanner(fn: ComponentType) {
   pageBanners.push(fn);
 }
 
-export const FNDashboard: React.Component<FNDashboardProps> = (props) => {
+export const FNDashboard: FC<FNDashboardProps> = (props) => {
   return (
-    <FnAppProvider FnError={props.fnError}>
+    <FnAppProvider fnError={props.fnError}>
       <div className="page-dashboard">
         <AngularRoot />
         <RenderFNDashboard {...props} />

--- a/public/app/fn-app/fn-dashboard-page/render-fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/render-fn-dashboard.tsx
@@ -5,12 +5,14 @@ import { ThunkDispatch } from 'redux-thunk';
 
 /* eslint-disable-next-line  */
 import { locationService as locationSrv, HistoryWrapper } from '@grafana/runtime';
-import { setInitialMountState } from 'app/core/reducers/fn-slice';
+import { setInitialMountState, updateFnState } from 'app/core/reducers/fn-slice';
 import DashboardPage, {
   Props,
   MapStateToDashboardPageProps,
   MappedDispatch,
 } from 'app/features/dashboard/containers/DashboardPage';
+import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
+import { cancelVariables } from 'app/features/variables/state/actions';
 import { DashboardRoutes, StoreState, useSelector } from 'app/types';
 
 import { Themeable2 } from '../../../../packages/grafana-ui/src/types/theme';
@@ -90,7 +92,16 @@ export const RenderFNDashboard: FC<FNDashboardProps> = (props) => {
 
     locationService.fnPathnameChange(window.location.pathname, queryParams);
 
-    return () => {};
+    return () => {
+      // getTimeSrv().stopAutoRefresh();
+      // dispatch(
+      //   updateFnState({
+      //     type: 'FNDashboard',
+      //     payload: false,
+      //   })
+      // );
+      // dispatch(cancelVariables(uid));
+    };
   }, [dispatch, uid, slug, theme, controlsContainer, pageTitle, hiddenVariables, queryParams]);
 
   const dashboardPageProps: DashboardPageProps = merge({}, DEFAULT_DASHBOARD_PAGE_PROPS, {

--- a/public/app/fn-app/types.ts
+++ b/public/app/fn-app/types.ts
@@ -1,9 +1,34 @@
-import { FunctionComponent } from 'react';
-export interface FNDashboardProps {
+import { ReactNode } from 'react';
+
+import { GrafanaThemeType } from '../../../packages/grafana-data/src/types/theme';
+
+export type FailedToMountGrafanaErrorName = 'FailedToMountGrafana';
+
+export interface GrafanaMicroFrontendState {
+  errors: Map<string | number, string | Error>;
+}
+
+export type GrafanaMicroFrontendActions = {
+  setErrors: (errors: GrafanaMicroFrontendState['errors']) => void;
+};
+
+/* eslint-disable-next-line  */
+export type AnyObject<K extends string | number | symbol = string, V = any> = {
+  [key in K]: V;
+};
+
+export interface FNDashboardProps<Q extends string = string> {
+  name: string;
   uid: string;
   slug: string;
-  controlsContainer: HTMLElement | undefined;
-  theme: string;
-  fnError: FunctionComponent;
+  theme: GrafanaThemeType;
+  queryParams: Partial<AnyObject<Q, string>>;
+  fnError?: ReactNode;
+  fnLoader?: ReactNode;
+  pageTitle?: string;
+  controlsContainer: HTMLElement | null;
+  setIsLoading: (isLoading: boolean) => void;
+  setErrors: (errors?: { [K: number | string]: string }) => void;
   hiddenVariables: string[];
+  container?: HTMLElement | null;
 }

--- a/public/app/fn-app/types.ts
+++ b/public/app/fn-app/types.ts
@@ -27,7 +27,7 @@ export interface FNDashboardProps<Q extends string = string> {
   fnLoader?: ReactNode;
   pageTitle?: string;
   controlsContainer: HTMLElement | null;
-  setIsLoading: (isLoading: boolean) => void;
+  isLoading: (isLoading: boolean) => void;
   setErrors: (errors?: { [K: number | string]: string }) => void;
   hiddenVariables: string[];
   container?: HTMLElement | null;

--- a/public/app/fn_app.ts
+++ b/public/app/fn_app.ts
@@ -8,6 +8,7 @@ import 'whatwg-fetch'; // fetch polyfill needed for PhantomJs rendering
 import './polyfills/old-mediaquerylist'; // Safari < 14 does not have mql.addEventListener()
 
 import 'app/features/all';
+import _ from 'lodash'; // eslint-disable-line lodash/import-scope
 
 import {
   locationUtil,

--- a/public/app/fn_dashboard.ts
+++ b/public/app/fn_dashboard.ts
@@ -10,4 +10,5 @@ config.featureToggles = {
 config.isPublicDashboardView = true;
 // eslint-disable-next-line
 config.bootData.themePaths = (window as any).fnData?.themePaths;
+
 export const { bootstrap, mount, unmount, update } = createMfe.create(FNDashboard);

--- a/public/app/fn_dashboard.ts
+++ b/public/app/fn_dashboard.ts
@@ -11,4 +11,5 @@ config.isPublicDashboardView = true;
 // eslint-disable-next-line
 config.bootData.themePaths = (window as any).fnData?.themePaths;
 
-export const { bootstrap, mount, unmount, update } = createMfe.create(FNDashboard);
+export const { bootstrap, mount, unmount, update, afterMount, afterUnmount, beforeLoad, beforeMount, beforeUnmount } =
+  createMfe.create(FNDashboard);

--- a/public/app/store/configureStore.ts
+++ b/public/app/store/configureStore.ts
@@ -1,5 +1,10 @@
-import { configureStore as reduxConfigureStore, MiddlewareArray } from '@reduxjs/toolkit';
-import { AnyAction } from 'redux';
+import {
+  configureStore as reduxConfigureStore,
+  EnhancedStore,
+  MiddlewareArray,
+  PreloadedState,
+} from '@reduxjs/toolkit';
+import { AnyAction, CombinedState } from 'redux';
 import { ThunkMiddleware } from 'redux-thunk';
 
 import { StoreState } from 'app/types/store';
@@ -9,6 +14,12 @@ import { addReducer, createRootReducer } from '../core/reducers/root';
 
 import { setStore } from './store';
 
+export type ConfiguredStore = EnhancedStore<
+  CombinedState<StoreState>,
+  AnyAction,
+  MiddlewareArray<[ThunkMiddleware<CombinedState<StoreState>, AnyAction>]>
+>;
+
 export function addRootReducer(reducers: any) {
   // this is ok now because we add reducers before configureStore is called
   // in the future if we want to add reducers during runtime
@@ -16,8 +27,8 @@ export function addRootReducer(reducers: any) {
   addReducer(reducers);
 }
 
-export function configureStore(initialState?: Partial<StoreState>) {
-  const store = reduxConfigureStore<StoreState, AnyAction, MiddlewareArray<[ThunkMiddleware<StoreState, AnyAction>]>>({
+export function configureStore<I extends Partial<PreloadedState<StoreState>>>(initialState?: I | Promise<I>) {
+  const store = reduxConfigureStore({
     reducer: createRootReducer(),
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({ thunk: true, serializableCheck: false, immutableCheck: false }),

--- a/public/app/types/dashboard.ts
+++ b/public/app/types/dashboard.ts
@@ -94,6 +94,7 @@ export enum KioskMode {
   Off = 'off',
   TV = 'tv',
   Full = 'full',
+  FN = 'fluxNinja',
 }
 
 export type GetMutableDashboardModelFn = () => DashboardModel | null;

--- a/public/test/redux-rtl.tsx
+++ b/public/test/redux-rtl.tsx
@@ -1,30 +1,29 @@
-import { AnyAction, configureStore } from '@reduxjs/toolkit';
-import { ThunkMiddlewareFor } from '@reduxjs/toolkit/dist/getDefaultMiddleware';
+import { configureStore, EnhancedStore, MiddlewareArray, PreloadedState } from '@reduxjs/toolkit';
 import { render as rtlRender } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
+import { AnyAction } from 'redux';
+import { ThunkMiddleware } from 'redux-thunk';
 
 import { createRootReducer } from 'app/core/reducers/root';
 import { StoreState } from 'app/types';
 
 import { mockNavModel } from './mocks/navModel';
 
+type Store = EnhancedStore<StoreState, AnyAction, MiddlewareArray<[ThunkMiddleware<StoreState, AnyAction, undefined>]>>;
+
 function render(
   ui: React.ReactElement,
   {
     preloadedState = { navIndex: mockNavModel },
-    store = configureStore<
-      StoreState,
-      AnyAction,
-      ReadonlyArray<ThunkMiddlewareFor<StoreState, { thunk: true; serializableCheck: false; immutableCheck: false }>>
-    >({
+    store = configureStore({
       reducer: createRootReducer(),
       preloadedState,
       middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware({ thunk: true, serializableCheck: false, immutableCheck: false }),
     }),
     ...renderOptions
-  }: { preloadedState?: Partial<StoreState>; store?: ReturnType<typeof configureStore> } = {}
+  }: { preloadedState?: Partial<PreloadedState<StoreState>>; store?: Store } = {}
 ) {
   function Wrapper({ children }: { children: React.ReactNode }) {
     return <Provider store={store}>{children}</Provider>;


### PR DESCRIPTION
 - [setErrors](https://github.com/fluxninja/grafana/pull/9/files) on error in Grafana state, now we can react to 4xx and 5xx
 - improve and add console.logs
 - imporve types (see screenshots :point_down: )
 - add [FN_README.md](https://github.com/fluxninja/grafana/pull/9/files#diff-2ed12e2a72cc366558afef5ef961ac059001244803720f17f2f36b8742f325fb)




TS after PR
![Screenshot from 2022-09-14 22-21-11](https://user-images.githubusercontent.com/24753130/190255070-4c68b03b-f715-453e-a280-5e84b66f7f1a.png)

TS errors before PR

![Screenshot from 2022-09-14 21-52-48](https://user-images.githubusercontent.com/24753130/190255223-c9341763-9b46-43c3-8382-ca515ccee6e1.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/grafana/9)
<!-- Reviewable:end -->
