### PR TITLE
6595 use grafana theme

### DIFF
--- a/packages/grafana-data/src/themes/fnCreateColors.ts
+++ b/packages/grafana-data/src/themes/fnCreateColors.ts
@@ -1,13 +1,14 @@
 import { merge } from 'lodash';
 
 import { alpha, darken, emphasize, getContrastRatio, lighten } from './colorManipulator';
-import { palette } from './palette';
-import { DeepPartial, ThemeRichColor } from './types';
-import {ThemeColorsBase, ThemeColorsMode, ThemeColors} from './createColors'
+import { ThemeColorsBase, ThemeColorsMode, ThemeColors, ThemeColorsInput } from './createColors';
+import { palette } from './fnPalette';
+import { ThemeRichColor } from './types';
 
-
-/** @internal */
-export type ThemeColorsInput = DeepPartial<ThemeColorsBase<ThemeRichColor>>;
+interface GetRichColorProps {
+  color: Partial<ThemeRichColor>;
+  name: string;
+}
 
 class FnDarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   mode: ThemeColorsMode = 'dark';
@@ -136,7 +137,7 @@ class FnLightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   };
 
   warning = {
-    main: '#F3D086',
+    main: '#EB7B18', // FN color
     text: palette.orangeLightText,
   };
 
@@ -166,6 +167,7 @@ class FnLightColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   tonalOffset = 0.2;
 }
 
+// NOTE: createFnColors used in create-mfe to create grafana theme2 colors
 export function createFnColors(colors: ThemeColorsInput): ThemeColors {
   const dark = new FnDarkColors();
   const light = new FnLightColors();
@@ -233,9 +235,4 @@ export function createFnColors(colors: ThemeColorsInput): ThemeColors {
     },
     other
   );
-}
-
-interface GetRichColorProps {
-  color: Partial<ThemeRichColor>;
-  name: string;
 }

--- a/packages/grafana-data/src/themes/fnPalette.ts
+++ b/packages/grafana-data/src/themes/fnPalette.ts
@@ -1,0 +1,42 @@
+export const palette = {
+  white: '#FFFFFF',
+  black: '#000000',
+
+  gray25: '#2c3235',
+  gray15: '#22252b',
+  gray10: '#181b1f',
+  gray05: '#111217',
+
+  darkLayer0: '#18181A',
+  darkLayer1: '#212124',
+  darkLayer2: '#2a2a2f',
+
+  darkBorder1: '#34343B',
+  darkBorder2: '#64646B',
+
+  // Dashboard bg / layer 0 (light theme)
+  gray90: '#F4F5F5',
+  // Card bg / layer 1
+  gray100: '#F4F5F5',
+  // divider line
+  gray80: '#D0D1D3',
+  lightBorder1: '#E4E7E7',
+
+  blueDarkMain: '#3D71D9',
+  blueDarkText: '#6E9FFF',
+  redDarkMain: '#D9534F', // FN - same as in light, final color to be agreed
+  redDarkText: '#13161B', // FN - same as in light, final color to be agreed
+  greenDarkMain: '#1A7F4B',
+  greenDarkText: '#6CCF8E',
+  orangeDarkMain: '#F5B73D',
+  orangeDarkText: '#F8D06B',
+
+  blueLightMain: '#3871DC',
+  blueLightText: '#1F62E0',
+  redLightMain: '#D9534F', // FN
+  redLightText: '#13161B', // FN
+  greenLightMain: '#1B855E',
+  greenLightText: '#0A764E',
+  orangeLightMain: '#FAD34A',
+  orangeLightText: '#8A6C00',
+};

--- a/public/app/core/components/Page/usePageTitle.ts
+++ b/public/app/core/components/Page/usePageTitle.ts
@@ -9,6 +9,7 @@ import { Branding } from '../Branding/Branding';
 
 export function usePageTitle(navModel?: NavModel, pageNav?: NavModelItem) {
   const { FNDashboard, pageTitle } = useSelector<StoreState, FnGlobalState>((state) => state.fnGlobalState);
+
   useEffect(() => {
     const parts: string[] = [];
 

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -1,8 +1,8 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import React, { CSSProperties } from 'react';
 import { useSelector } from 'react-redux';
 
 import { TimeRange, isDateTime, toUtc } from '@grafana/data';
-import { TimeRangePickerProps, TimeRangePicker } from '@grafana/ui';
+import { TimeRangePickerProps, TimeRangePicker, useTheme2 } from '@grafana/ui';
 import { FnGlobalState } from 'app/core/reducers/fn-slice';
 import { StoreState } from 'app/types';
 
@@ -12,20 +12,16 @@ const LOCAL_STORAGE_KEY = 'grafana.dashboard.timepicker.history';
 
 interface Props extends Omit<TimeRangePickerProps, 'history' | 'theme'> {}
 
-const FN_TEXT_STYLE: CSSProperties = { fontWeight: 700, fontSize: 14, marginLeft: 8 };
+const FnText: React.FC = () => {
+  const { FNDashboard } = useSelector<StoreState, FnGlobalState>(({ fnGlobalState }) => fnGlobalState);
+  const theme = useTheme2();
+
+  const FN_TEXT_STYLE: CSSProperties = { fontWeight: 700, fontSize: 14, marginLeft: 8 };
+
+  return <>{FNDashboard ? <span style={{ ...FN_TEXT_STYLE, color: theme.colors.warning.main }}>UTC</span> : ''}</>;
+};
 
 export const TimePickerWithHistory: React.FC<Props> = (props) => {
-  const { FNDashboard, theme } = useSelector<StoreState, FnGlobalState>((state) => state.fnGlobalState);
-
-  // @ts-ignore
-  const fnColor = FNDashboard ? theme?.palette?.secondary?.light : null;
-
-  const fnText: ReactNode = FNDashboard ? (
-    <span style={{ ...(fnColor ? { color: fnColor } : {}), ...FN_TEXT_STYLE }}>UTC</span>
-  ) : (
-    ''
-  );
-
   return (
     <LocalStorageValueProvider<TimeRange[]> storageKey={LOCAL_STORAGE_KEY} defaultValue={[]}>
       {(values, onSaveToStore) => {
@@ -37,7 +33,7 @@ export const TimePickerWithHistory: React.FC<Props> = (props) => {
               onAppendToHistory(value, values, onSaveToStore);
               props.onChange(value);
             }}
-            {...{ fnText }}
+            fnText={<FnText />}
           />
         );
       }}

--- a/public/app/core/reducers/fn-slice.ts
+++ b/public/app/core/reducers/fn-slice.ts
@@ -1,10 +1,8 @@
-import { Theme as MuiTheme } from '@mui/material';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { WritableDraft } from 'immer/dist/internal';
 
-import { createTheme, GrafanaThemeType } from '@grafana/data';
+import { GrafanaThemeType } from '@grafana/data';
 
-import { GrafanaTheme } from '../../../../packages/grafana-data/src/types/theme';
 import { AnyObject } from '../../fn-app/types';
 
 export interface FnGlobalState {
@@ -12,45 +10,19 @@ export interface FnGlobalState {
   uid: string;
   slug: string;
   mode: GrafanaThemeType.Light | GrafanaThemeType.Dark;
-  theme: FnTheme;
   controlsContainer: HTMLElement | null | undefined;
   pageTitle: string;
   queryParams: AnyObject;
   hiddenVariables: string[];
 }
 
-/**
- * NOTE:
- * The initial assumption was that the MuiTheme is used.
- * Taking into account the below type (GrafanaThemeProps do not map to MuiTheme),
- * it looks like we may consider to use GrafanaTheme instead of MuiTheme (TODO)
- */
-export type FnTheme = Omit<MuiTheme, OptionalThemeProp | GrafanaThemeProp> &
-  Partial<Pick<MuiTheme, OptionalThemeProp>> & {
-    palette: GrafanaTheme['palette'];
-    shadows: GrafanaTheme['shadows'];
-    typography: GrafanaTheme['typography'];
-    zIndex: GrafanaTheme['zIndex'];
-    breakpoints: GrafanaTheme['breakpoints'];
-    spacing: GrafanaTheme['spacing'];
-  };
-
-type OptionalThemeProp = Extract<keyof MuiTheme, 'mixins' | 'transitions' | 'shape' | 'direction'>;
-
-type GrafanaThemeProp = Extract<
-  keyof MuiTheme,
-  'palette' | 'shadows' | 'typography' | 'zIndex' | 'breakpoints' | 'spacing'
->;
-
 const INITIAL_MODE = GrafanaThemeType.Light;
-const INITIAL_THEME = createTheme({ colors: { mode: INITIAL_MODE } });
 
 const initialState: FnGlobalState = {
   FNDashboard: false,
   uid: '',
   slug: '',
   mode: INITIAL_MODE,
-  theme: INITIAL_THEME.v1,
   controlsContainer: null,
   pageTitle: '',
   queryParams: {},
@@ -62,8 +34,7 @@ const fnSlice = createSlice({
   initialState,
   reducers: {
     setInitialMountState: (state, action: PayloadAction<FnGlobalState>) => {
-
-      return {...state, ...action.payload};
+      return { ...state, ...action.payload };
     },
     updateFnState: (
       state: WritableDraft<FnGlobalState>,
@@ -75,7 +46,6 @@ const fnSlice = createSlice({
         ...state,
         [type]: payload,
       };
-
     },
   },
 });

--- a/public/app/features/variables/pickers/PickerRenderer.tsx
+++ b/public/app/features/variables/pickers/PickerRenderer.tsx
@@ -1,9 +1,8 @@
 import React, { CSSProperties, FunctionComponent, PropsWithChildren, ReactElement, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { GrafanaThemeType } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Tooltip } from '@grafana/ui';
+import { Tooltip, useTheme2 } from '@grafana/ui';
 import { FnGlobalState } from 'app/core/reducers/fn-slice';
 import type { StoreState } from 'app/types';
 
@@ -41,35 +40,8 @@ const COMMON_PICKER_LABEL_STYLE: CSSProperties = {
 
 function PickerLabel({ variable }: PropsWithChildren<Props>): ReactElement | null {
   const labelOrName = useMemo(() => variable.label || variable.name, [variable]);
-  const { FNDashboard, mode, theme } = useSelector<StoreState, FnGlobalState>((state) => state.fnGlobalState);
-
-  const changeLabelStyle = useMemo(() => {
-    if (!FNDashboard) {
-      return {};
-    }
-
-    /**
-     * TODO:
-     * The below ts-ignores result from the fact that we expect MuiTheme in Grafana
-     * Let's pass GrafanaTheme
-     */
-    // @ts-ignore
-    const color = theme?.palette?.text?.primary;
-    // @ts-ignore
-    const lightBackgroundColor = theme?.palette?.grey;
-    // @ts-ignore
-    const darkBackgroundColor = theme?.palette?.background?.default;
-
-    const commonStyles: CSSProperties = {
-      ...COMMON_PICKER_LABEL_STYLE,
-      ...(color ? { color } : {}),
-    };
-
-    const backgroundColor = mode === GrafanaThemeType.Light ? lightBackgroundColor : darkBackgroundColor;
-    const createLabelTheme: CSSProperties = backgroundColor ? { backgroundColor } : {};
-
-    return { ...createLabelTheme, ...commonStyles };
-  }, [FNDashboard, mode, theme]);
+  const { FNDashboard } = useSelector<StoreState, FnGlobalState>(({ fnGlobalState }) => fnGlobalState);
+  const theme = useTheme2();
 
   if (variable.hide !== VariableHide.dontHide) {
     return null;
@@ -82,7 +54,7 @@ function PickerLabel({ variable }: PropsWithChildren<Props>): ReactElement | nul
       <Tooltip content={variable.description} placement={'bottom'}>
         <label
           className="gf-form-label gf-form-label--variable"
-          style={FNDashboard ? changeLabelStyle : {}}
+          style={FNDashboard ? { ...COMMON_PICKER_LABEL_STYLE, color: theme.colors.text.secondary } : {}}
           data-testid={selectors.pages.Dashboard.SubMenu.submenuItemLabels(labelOrName)}
           htmlFor={elementId}
         >
@@ -94,7 +66,7 @@ function PickerLabel({ variable }: PropsWithChildren<Props>): ReactElement | nul
   return (
     <label
       className="gf-form-label gf-form-label--variable"
-      style={FNDashboard ? changeLabelStyle : {}}
+      style={FNDashboard ? { ...COMMON_PICKER_LABEL_STYLE, color: theme.colors.text.secondary } : {}}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItemLabels(labelOrName)}
       htmlFor={elementId}
     >

--- a/public/app/fn-app/fn-dashboard-page/render-fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/render-fn-dashboard.tsx
@@ -41,7 +41,6 @@ export const RenderFNDashboard: FC<FNDashboardProps> = (props) => {
     queryParams,
     uid,
     slug,
-    theme,
     mode,
     controlsContainer,
     pageTitle = '',
@@ -81,7 +80,6 @@ export const RenderFNDashboard: FC<FNDashboardProps> = (props) => {
         FNDashboard: true,
         uid,
         slug,
-        theme,
         mode,
         controlsContainer,
         pageTitle,
@@ -111,7 +109,7 @@ export const RenderFNDashboard: FC<FNDashboardProps> = (props) => {
       );
       dispatch(cancelVariables(uid));
     };
-  }, [dispatch, uid, slug, theme, controlsContainer, pageTitle, hiddenVariables, queryParams, mode]);
+  }, [dispatch, uid, slug, controlsContainer, pageTitle, hiddenVariables, queryParams, mode]);
 
   const dashboardPageProps: DashboardPageProps = merge({}, DEFAULT_DASHBOARD_PAGE_PROPS, {
     ...DEFAULT_DASHBOARD_PAGE_PROPS,

--- a/public/app/fn-app/types.ts
+++ b/public/app/fn-app/types.ts
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 
 import { GrafanaThemeType } from '@grafana/data';
-import { FnTheme } from 'app/core/reducers/fn-slice';
 
 export type FailedToMountGrafanaErrorName = 'FailedToMountGrafana';
 
@@ -18,13 +17,12 @@ export type AnyObject<K extends string | number | symbol = string, V = any> = {
   [key in K]: V;
 };
 
-export interface FNDashboardProps<Q extends string = string> {
+export interface FNDashboardProps {
   name: string;
   uid: string;
   slug: string;
   mode: GrafanaThemeType.Dark | GrafanaThemeType.Light;
-  theme: FnTheme;
-  queryParams: Partial<AnyObject<Q, string>>;
+  queryParams: Partial<AnyObject<string, string>>;
   fnError?: ReactNode;
   fnLoader?: ReactNode;
   pageTitle?: string;


### PR DESCRIPTION
- use grafana theme
- remove theme prop (mode is enough)
- extract fn comoponents (tin order to make the futire rebasing on grafana/main easier)
- improve types and eslint

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/grafana/29)
<!-- Reviewable:end -->
