### PR TITLE
7829 Read hiddenVariables, mode, FNDashboard from grfana's state

### DIFF
--- a/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenu.tsx
@@ -3,6 +3,7 @@ import React, { PureComponent } from 'react';
 import { connect, MapStateToProps } from 'react-redux';
 
 import { AnnotationQuery, DataQuery } from '@grafana/data';
+import { FnGlobalState } from 'app/core/reducers/fn-slice';
 
 import { StoreState } from '../../../../types';
 import { getSubMenuVariables, getVariablesState } from '../../../variables/state/selectors';
@@ -18,11 +19,11 @@ interface OwnProps {
   dashboard: DashboardModel;
   links: DashboardLink[];
   annotations: AnnotationQuery[];
-  hiddenVariables?: string[];
 }
 
 interface ConnectedProps {
   variables: VariableModel[];
+  hiddenVariables: FnGlobalState['hiddenVariables'];
 }
 
 interface DispatchProps {}
@@ -76,8 +77,10 @@ class SubMenuUnConnected extends PureComponent<Props> {
 const mapStateToProps: MapStateToProps<ConnectedProps, OwnProps, StoreState> = (state, ownProps) => {
   const { uid } = ownProps.dashboard;
   const templatingState = getVariablesState(uid, state);
+
   return {
     variables: getSubMenuVariables(uid, templatingState.variables),
+    hiddenVariables: state.fnGlobalState.hiddenVariables,
   };
 };
 

--- a/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
+++ b/public/app/features/dashboard/components/SubMenu/SubMenuItems.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent, useEffect, useState } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
+import { FnGlobalState } from 'app/core/reducers/fn-slice';
 
 import { PickerRenderer } from '../../../variables/pickers/PickerRenderer';
 import { VariableHide, VariableModel } from '../../../variables/types';
@@ -8,7 +9,7 @@ import { VariableHide, VariableModel } from '../../../variables/types';
 interface Props {
   variables: VariableModel[];
   readOnly?: boolean;
-  hiddenVariables?: string[];
+  hiddenVariables?: FnGlobalState['hiddenVariables'];
 }
 
 export const SubMenuItems: FunctionComponent<Props> = ({ variables, readOnly, hiddenVariables }) => {

--- a/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
+++ b/public/app/fn-app/fn-dashboard-page/fn-dashboard.tsx
@@ -1,7 +1,17 @@
+import { pick } from 'lodash';
 import { parse as parseQueryParams } from 'query-string';
 import React, { FC, Suspense, useMemo } from 'react';
 import { lazily } from 'react-lazily';
+import { connect, MapStateToProps } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+
+import {
+  FnGlobalState,
+  FN_STATE_KEY,
+  FnPropMappedFromState,
+  fnPropsMappedFromState,
+  FnPropsMappedFromState,
+} from 'app/core/reducers/fn-slice';
 
 import { FNDashboardProps } from '../types';
 import { RenderPortal } from '../utils';
@@ -10,39 +20,61 @@ const { RenderFNDashboard } = lazily(() => import('./render-fn-dashboard'));
 const { FnAppProvider } = lazily(() => import('../fn-app-provider'));
 const { AngularRoot } = lazily(() => import('../../angular/AngularRoot'));
 
-export const FNDashboard: FC<FNDashboardProps> = (props) => (
-  <Suspense fallback={<>{props.fnLoader}</>}>
-    <FnAppProvider fnError={props.fnError}>
-      <div className="page-dashboard">
-        <AngularRoot />
-        <DashboardPortal {...props}/>
-      </div>
-    </FnAppProvider>
-  </Suspense>
-);
+type FNDashboardComponentProps = Omit<FNDashboardProps, FnPropMappedFromState>;
 
-export const DashboardPortal: FC<FNDashboardProps> = (props) =>{
+export const FNDashboard: FC<FNDashboardComponentProps> = (props) => {
+  return (
+    <Suspense fallback={<>{props.fnLoader}</>}>
+      <FnAppProvider fnError={props.fnError}>
+        <div className="page-dashboard">
+          <AngularRoot />
+          <DashboardPortal {...props} />
+        </div>
+      </FnAppProvider>
+    </Suspense>
+  );
+};
+
+function mapStateToProps(): MapStateToProps<
+  FnPropsMappedFromState,
+  Omit<FNDashboardProps, FnPropMappedFromState>,
+  { [K in typeof FN_STATE_KEY]: FnGlobalState }
+> {
+  return ({ fnGlobalState }) => pick(fnGlobalState, ...fnPropsMappedFromState);
+}
+
+export const DashboardPortalComponent: FC<FNDashboardComponentProps & FnPropsMappedFromState> = (props) => {
   const location = useLocation();
 
-  const portal = useMemo(() =>{
+  const content = useMemo(() => {
+    if (!props.FNDashboard) {
+      // TODO Use no data
+      return null;
+    }
+
     const { search } = location;
     const queryParams = parseQueryParams(search);
 
-    const { dashboardUID, slug } = queryParams
+    const { dashboardUID: uid, slug } = queryParams as { dashboardUID?: string; slug?: string };
 
-    const newProps: FNDashboardProps = {
-      ...props,
-      uid: dashboardUID as string,
-      slug: slug as string,
-      queryParams,
+    if (!uid || !slug) {
+      // TODO Use no data
+      return null;
     }
-    
-    return dashboardUID &&(
-      <RenderPortal ID="grafana-portal" >
-        <RenderFNDashboard {...newProps} />
-      </RenderPortal>
-    )
-  },[location, props])
 
-  return <>{portal}</>
-}
+    return (
+      <RenderFNDashboard
+        {...{
+          ...props,
+          uid,
+          slug,
+          queryParams,
+        }}
+      />
+    );
+  }, [location, props]);
+
+  return <RenderPortal ID="grafana-portal">{content}</RenderPortal>;
+};
+
+export const DashboardPortal = connect(mapStateToProps())(DashboardPortalComponent);

--- a/public/app/fn-app/types.ts
+++ b/public/app/fn-app/types.ts
@@ -30,6 +30,6 @@ export interface FNDashboardProps {
   controlsContainer: string;
   isLoading: (isLoading: boolean) => void;
   setErrors: (errors?: { [K: number | string]: string }) => void;
-  hiddenVariables: string[];
+  hiddenVariables: readonly string[];
   container?: HTMLElement | null;
 }


### PR DESCRIPTION
Ref: https://github.com/fluxninja/cloud/issues/7829


Use global grafana's state (redux) to propagate mode, hiddenVariables, FNDashboard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/grafana/44)
<!-- Reviewable:end -->
