### PR TITLE
8740 Fix variables in titles by using PanelHeader component to render…

### DIFF
--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -625,9 +625,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
           className={containerClassNames}
           aria-label={selectors.components.Panels.Panel.containerByTitle(panel.title)}
         >
-          {FNDashboard ? (
-            <p style={FN_TITLE_STYLE}>{panel.title}</p>
-          ) : (
+          <div style={FNDashboard ?  FN_TITLE_STYLE : {}}>
             <PanelHeader
               panel={panel}
               dashboard={dashboard}
@@ -640,7 +638,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
               alertState={alertState}
               data={data}
             />
-          )}
+            </div>
           <ErrorBoundary
             dependencies={[data, plugin, panel.getOptions()]}
             onError={this.onPanelError}


### PR DESCRIPTION
… panel header


![Screenshot from 2023-03-15 15-08-57](https://user-images.githubusercontent.com/24753130/225334978-96e4527a-dcef-4457-a8ee-15347c8c2907.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/grafana/64)
<!-- Reviewable:end -->




<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Here are the release notes for this pull request:

```
Bug fix: Fixed variables in titles by using PanelHeader component to render them.
```

This pull request fixes an issue where variables in titles were not being rendered correctly. The fix involves removing a paragraph tag and adding a div tag to wrap the PanelHeader component. This change improves the user experience by ensuring that titles are displayed correctly.
<!-- end of auto-generated comment: release notes by openai -->