### PR TITLE
8963 Remove edit icons in dashboard row

### DIFF
--- a/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
+++ b/public/app/features/dashboard/components/DashboardRow/DashboardRow.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Unsubscribable } from 'rxjs';
+import {connect} from "react-redux"
 
 import { selectors } from '@grafana/e2e-selectors';
 import { getTemplateSrv, RefreshEvent } from '@grafana/runtime';
@@ -11,13 +12,15 @@ import { ShowConfirmModalEvent } from '../../../../types/events';
 import { DashboardModel } from '../../state/DashboardModel';
 import { PanelModel } from '../../state/PanelModel';
 import { RowOptionsButton } from '../RowOptions/RowOptionsButton';
+import { StoreState } from 'app/types';
 
 export interface DashboardRowProps {
   panel: PanelModel;
   dashboard: DashboardModel;
+  isFnDashboard: boolean
 }
 
-export class DashboardRow extends React.Component<DashboardRowProps> {
+ class Component extends React.Component<DashboardRowProps> {
   sub?: Unsubscribable;
 
   componentDidMount() {
@@ -69,10 +72,13 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
       'dashboard-row--collapsed': this.props.panel.collapsed,
     });
 
+    const {isFnDashboard} = this.props
+
     const title = getTemplateSrv().replace(this.props.panel.title, this.props.panel.scopedVars, 'text');
     const count = this.props.panel.panels ? this.props.panel.panels.length : 0;
     const panels = count === 1 ? 'panel' : 'panels';
-    const canEdit = this.props.dashboard.meta.canEdit === true;
+    const canEdit = this.props.dashboard.meta.canEdit === true && !isFnDashboard;
+
 
     return (
       <div className={classes} data-testid="dashboard-row-container">
@@ -110,3 +116,13 @@ export class DashboardRow extends React.Component<DashboardRowProps> {
     );
   }
 }
+
+
+function mapStateToProps () {
+  return (state: StoreState) =>  ({
+    isFnDashboard: state.fnGlobalState.FNDashboard
+  });
+}
+
+
+export const DashboardRow = connect(mapStateToProps)(Component);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:

- Refactor: Remove edit icons in dashboard rows and add a new prop `isFnDashboard` to determine if it's an FNDashboard.

> "Edit icons no more, 
> Dashboard rows are now clean. 
> A refactor done right."
<!-- end of auto-generated comment: release notes by openai -->