### PR TITLE
Fix table panel

### DIFF
--- a/packages/grafana-ui/src/components/Table/Table.tsx
+++ b/packages/grafana-ui/src/components/Table/Table.tsx
@@ -63,8 +63,6 @@ export const Table = memo((props: Props) => {
   const tableStyles = useTableStyles(theme, cellHeight);
   const headerHeight = noHeader ? 0 : tableStyles.rowHeight;
   const [footerItems, setFooterItems] = useState<FooterItem[] | undefined>(footerValues);
-  const [expandedIndexes, setExpandedIndexes] = useState<Set<number>>(new Set());
-  const prevExpandedIndexes = usePrevious(expandedIndexes);
 
   const footerHeight = useMemo(() => {
     const EXTENDED_ROW_HEIGHT = FOOTER_ROW_HEIGHT;


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Refactor:
- Removed `expandedIndexes` state and its previous value reference from Table.tsx
- Eliminated the `usePrevious` hook usage in Table.tsx
```

> 🎉 A refactor we did embrace,
> To simplify Table's state space.
> Farewell, expandedIndexes dear,
> And usePrevious, disappear! 🚀
<!-- end of auto-generated comment: release notes by openai -->