### PR TITLE
Fix absolute timerange history crash

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -198,9 +198,14 @@ export const describeTimeRangeAbbreviation = (range: TimeRange, timeZone?: TimeZ
   return parsed ? timeZoneAbbrevation(parsed, { timeZone }) : '';
 };
 
-export const convertRawToRange = (raw: RawTimeRange, timeZone?: TimeZone, fiscalYearStartMonth?: number): TimeRange => {
-  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth });
-  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth });
+export const convertRawToRange = (
+  raw: RawTimeRange,
+  timeZone?: TimeZone,
+  fiscalYearStartMonth?: number,
+  format?: string
+): TimeRange => {
+  const from = dateTimeParse(raw.from, { roundUp: false, timeZone, fiscalYearStartMonth, format });
+  const to = dateTimeParse(raw.to, { roundUp: true, timeZone, fiscalYearStartMonth, format });
 
   if (dateMath.isMathString(raw.from) || dateMath.isMathString(raw.to)) {
     return { from, to, raw };

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimePickerContent.tsx
@@ -288,7 +288,7 @@ const getStyles = stylesFactory((theme: GrafanaTheme2, isReversed, hideQuickRang
       flex-direction: column;
       border-right: ${isReversed ? 'none' : `1px solid ${theme.colors.border.weak}`};
       width: ${!hideQuickRanges ? '50%' : '100%'};
-      overflow: hidden;
+      overflow: auto;
       order: ${isReversed ? 1 : 0};
     `,
     rightSide: css`


### PR DESCRIPTION
Fixes https://github.com/fluxninja/cloud/issues/9957
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
New Feature:
- Added support for custom date formats in TimeRangePicker
- Improved TimePicker history handling with new LSTimePickerHistoryItem type

Bug fix:
- Fixed overflow issue in TimePickerContent by enabling scrolling
```

> 🎉 A format so grand, the dates understand,
> 📜 TimeRangePicker now takes a stand.
> ⏳ The history refined, no longer confined,
> 🔄 Overflow fixed, a smooth scroll we find.
<!-- end of auto-generated comment: release notes by openai -->