### PR TITLE
Fix graphs not using the global timerange

### DIFF
--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -65,15 +65,17 @@ export const Picker: FC<PickerProps> = ({ rawValues, onSaveToStore, pickerProps 
           })
         );
       }
+    } else if (fnGlobalTimeRange) {
+      /* If fnGlobalTimeRange exists in the initial render, set the time as that */
+      pickerProps.onChange(fnGlobalTimeRange);
     }
 
     didMountRef.current = true;
-  }, [dispatch, fnGlobalTimeRange?.raw, pickerProps.value]);
+  }, [dispatch, fnGlobalTimeRange, pickerProps]);
 
   return (
     <TimeRangePicker
       {...pickerProps}
-      value={fnGlobalTimeRange || pickerProps.value}
       history={history}
       onChange={(value) => {
         onAppendToHistory(value, values, onSaveToStore);

--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -65,7 +65,7 @@ export const Picker: FC<PickerProps> = ({ rawValues, onSaveToStore, pickerProps 
           })
         );
       }
-    } else if (fnGlobalTimeRange) {
+    } else if (fnGlobalTimeRange && !isEqual(fnGlobalTimeRange, pickerProps.value)) {
       /* If fnGlobalTimeRange exists in the initial render, set the time as that */
       pickerProps.onChange(fnGlobalTimeRange);
     }


### PR DESCRIPTION
Ref https://github.com/fluxninja/cloud/issues/8859
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Fixed issue with graphs not displaying correctly by setting default time range to `fnGlobalTimeRange` if it exists and is not equal to the current value
- Removed `value` prop from `TimeRangePicker` component
```

> 🎉 Time's mysteries, now we unveil,
> With graphs displayed, our quest won't fail.
> A picker's change, a bug we quell,
> In code's embrace, our triumphs dwell. 🚀
<!-- end of auto-generated comment: release notes by openai -->