### PR TITLE
Compare raw timerange values

### DIFF
--- a/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
+++ b/public/app/core/components/TimePicker/TimePickerWithHistory.tsx
@@ -65,7 +65,7 @@ export const Picker: FC<PickerProps> = ({ rawValues, onSaveToStore, pickerProps 
           })
         );
       }
-    } else if (fnGlobalTimeRange && !isEqual(fnGlobalTimeRange, pickerProps.value)) {
+    } else if (fnGlobalTimeRange && !isEqual(fnGlobalTimeRange.raw, pickerProps.value.raw)) {
       /* If fnGlobalTimeRange exists in the initial render, set the time as that */
       pickerProps.onChange(fnGlobalTimeRange);
     }


### PR DESCRIPTION
Minor fix, missed it in my previous PR #79
<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

```
Bug fix:
- Adjusted TimePicker comparison logic to only compare `raw` properties of time range objects
```

> 🎉 A subtle change, a bug we did tame,
> Comparing `raw`, our aim now the same.
> TimePicker's logic, improved and refined,
> A smoother experience, users will find. 🕰️
<!-- end of auto-generated comment: release notes by openai -->