### PR TITLE
Remove font size from global styles

### DIFF
--- a/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/elements.ts
@@ -10,7 +10,6 @@ export function getElementStyles(theme: GrafanaTheme2) {
       -ms-overflow-style: scrollbar;
       -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
       height: 100%;
-      font-size: ${theme.typography.htmlFontSize}px;
       font-family: ${theme.typography.fontFamily};
       line-height: ${theme.typography.body.lineHeight};
       font-kerning: normal;

--- a/public/sass/base/_reboot.scss
+++ b/public/sass/base/_reboot.scss
@@ -64,14 +64,12 @@ html {
 
 // This is specified in runtime Emotion GlobalStyles but we need them for the Grafana loading styles
 html {
-  font-size: $font-size-base;
   height: 100%;
 }
 
 // This is specified in runtime Emotion GlobalStyles but we need them for the Grafana loading styles
 body {
   font-family: $font-family-sans-serif;
-  font-size: $font-size-base;
   line-height: $line-height-base;
   color: $text-color;
   background-color: $body-bg;


### PR DESCRIPTION
Resolves https://github.com/fluxninja/cloud/issues/10919
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Style: Removed the `font-size` property from the global styles in Grafana UI. This change addresses an issue related to Grafana's style loading process, improving the consistency and reliability of the user interface display across different environments.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->