### PR TITLE
Fixed CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
         description: ArgoCD manifests repository to update
       manifests-branch:
         type: string
-        default: tests
+        default: environments/latest
         description: Branch to use when pushing deployment changes
       environment-path:
         type: string

--- a/.circleci/scripts/update_environment.sh
+++ b/.circleci/scripts/update_environment.sh
@@ -9,6 +9,10 @@ args=(
     --author "${commit_author}"
     --update "${UPDATE}"
     --release-train "latest"
+    --manifests-repo-url "${MANIFESTS_REPO}"
+    --manifests-base-branch "${MANIFESTS_BRANCH}"
+    --manifests-repo-ref "${MANIFESTS_BRANCH}"
+    --skip-pull-request
     --push
 )
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: Updated the CircleCI configuration and scripts. The default value of the `manifests-branch` parameter has been changed from "tests" to "environments/latest". This change aligns with our latest workflow updates.
- New Feature: Added new arguments to the CircleCI config, including URL, base branch, and repository reference for manifests. This enhancement provides more flexibility in managing different environments.
- New Feature: Introduced a `--skip-pull-request` argument to optionally bypass the creation of a pull request. This feature speeds up the development process when testing changes internally.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->