### PR TITLE
Disable Grafana API Keys

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -189,7 +189,8 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			switch {
 			case h.initContextWithRenderAuth(reqContext):
 			case h.initContextWithJWT(reqContext, orgID):
-			case h.initContextWithAPIKey(reqContext):
+			// Disabled as it does not work with Aperture Cloud User API Keys.
+			//case h.initContextWithAPIKey(reqContext):
 			case h.initContextWithBasicAuth(reqContext, orgID):
 			case h.initContextWithAuthProxy(reqContext, orgID):
 			case h.initContextWithToken(reqContext, orgID):

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -191,7 +191,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 			case h.initContextWithJWT(reqContext, orgID):
 			// Disabled as it does not work with Aperture Cloud User API Keys.
 			//case h.initContextWithAPIKey(reqContext):
-			case h.initContextWithBasicAuth(reqContext, orgID):
+			//case h.initContextWithBasicAuth(reqContext, orgID):
 			case h.initContextWithAuthProxy(reqContext, orgID):
 			case h.initContextWithToken(reqContext, orgID):
 			case h.initContextWithAnonymousUser(reqContext):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Updated the `Middleware` function in the `ContextHandler` struct within `contexthandler.go`. The initialization of context with API keys, including the `initContextWithAPIKey` function call and basic authentication, has been disabled. This change enhances compatibility with Aperture Cloud User API Keys.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->