### PR TITLE
Add missing config in opsninja.yaml

### DIFF
--- a/.opsninja.yaml
+++ b/.opsninja.yaml
@@ -6,3 +6,6 @@ applications:
     image:
       name: grafana
       dockerfile: Dockerfile
+    argo_manifests:
+      - app_path: apps/app-of-apps/cloud/cloud-prometheus.yaml
+        image_prefix: NINJA_GRAFANA_


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Added a new configuration entry in the `opsninja.yaml` file. This update allows users to specify the path to an application manifest file and an image prefix for Grafana, enhancing the flexibility and customization of the deployment process.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->