### PR TITLE
page definations fix for user

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -319,12 +319,4 @@ export const Pages = {
       },
     },
   },
-  UserListPage: {
-    org: {
-      url: '/org/users',
-    },
-    admin: {
-      url: '/admin/users',
-    },
-  },
 };


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: Removed the `UserListPage` definition from the `Pages` object in Grafana e2e selectors. This change simplifies the code structure and may affect how users interact with organization and admin user URLs. Please update your usage accordingly if you were relying on this definition.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->