### PR TITLE
Pass headers to Druid query

### DIFF
--- a/pkg/tsdb/druid/druid.go
+++ b/pkg/tsdb/druid/druid.go
@@ -502,21 +502,21 @@ func (ds *Service) executeQuery(
 		return nil, errors.New("not implemented")
 	case "timeseries":
 		var r result.TimeseriesResult
-		_, err := s.client.Query().Execute(q, &r)
+		_, err := s.client.Query().Execute(q, &r, headers)
 		if err != nil {
 			return nil, fmt.Errorf("Query error: %w", err)
 		}
 		resultFramer = &r
 	case "topN":
 		var r result.TopNResult
-		_, err := s.client.Query().Execute(q, &r)
+		_, err := s.client.Query().Execute(q, &r, headers)
 		if err != nil {
 			return nil, fmt.Errorf("Query error: %w", err)
 		}
 		resultFramer = &r
 	case "groupBy":
 		var r result.GroupByResult
-		_, err := s.client.Query().Execute(q, &r)
+		_, err := s.client.Query().Execute(q, &r, headers)
 		if err != nil {
 			return nil, fmt.Errorf("Query error: %w", err)
 		}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Enhanced the `executeQuery` function in the Druid service. Now, it supports passing additional headers during the execution of `timeseries`, `topN`, and `groupBy` queries. This update provides more flexibility and control over query execution, allowing users to include specific header information as part of their data requests.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->