### PR TITLE
Don't panic on empty var Druid query

### DIFF
--- a/pkg/tsdb/druid/column_type.go
+++ b/pkg/tsdb/druid/column_type.go
@@ -7,6 +7,10 @@ import (
 )
 
 func detectColumnType(c *responseColumn, pos int, rows [][]interface{}) {
+	if len(rows) == 0 {
+		c.Type = ColumnString
+		return
+	}
 	t := map[columnType]int{"nil": 0}
 	maxRowsToScan := (len(rows) / 5) + 1
 	for _, row := range rows[:maxRowsToScan] {

--- a/pkg/tsdb/druid/druid.go
+++ b/pkg/tsdb/druid/druid.go
@@ -608,8 +608,11 @@ func (ds *Service) oldExecuteQuery(queryRef string, q druidquerybuilder.Query, s
 		err := json.Unmarshal(res, &tn)
 		if err == nil && len(tn) > 0 {
 			columns := []string{"timestamp"}
-			for c := range tn[0]["result"].([]interface{})[0].(map[string]interface{}) {
-				columns = append(columns, c)
+			results := tn[0]["result"].([]interface{})
+			if len(results) > 0 {
+				for c := range results[0].(map[string]interface{}) {
+					columns = append(columns, c)
+				}
 			}
 			for _, result := range tn {
 				for _, record := range result["result"].([]interface{}) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
---
- Bug Fix: Enhanced stability of Druid data source by adding checks for empty arrays or slices in the `detectColumnType` function and during column name extraction from a Druid query result. This prevents potential application crashes when encountering an empty `rows` slice or result array.
---
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->