### PR TITLE
Add allowed cookies field in druid datasource settings

### DIFF
--- a/public/app/plugins/datasource/grafadruid-druid-datasource/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/grafadruid-druid-datasource/ConfigEditor.tsx
@@ -57,9 +57,9 @@ export class ConfigEditor extends PureComponent<Props, State> {
 
   onConnectionOptionsChange = (connectionSettingsOptions: ConnectionSettingsOptions) => {
     const { options, onOptionsChange } = this.props;
-    const { settings, secretSettings, secretSettingsFields } = connectionSettingsOptions;
+    const { settings, secretSettings, secretSettingsFields, jsonData: connectionJsonData } = connectionSettingsOptions;
     const connectionSettings = this.normalizeData(settings, true, 'connection');
-    const jsonData = { ...options.jsonData, ...connectionSettings };
+    const jsonData = { ...options.jsonData, ...connectionSettings, ...connectionJsonData };
     const connectionSecretSettings = this.normalizeData(secretSettings, true, 'connection');
     const secureJsonData = { ...options.secureJsonData, ...connectionSecretSettings };
     const connectionSecretSettingsFields = this.normalizeData(
@@ -85,6 +85,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       settings: this.normalizeData(jsonData, false, 'connection'),
       secretSettings: this.normalizeData(secureJsonData || {}, false, 'connection'),
       secretSettingsFields: this.normalizeData(secureJsonFields || {}, false, 'connection') as KeyValue<boolean>,
+      jsonData: { keepCookies: (jsonData as ConnectionSettingsOptions['jsonData'])?.keepCookies || [] },
     };
   };
 

--- a/public/app/plugins/datasource/grafadruid-druid-datasource/configuration/ConnectionSettings/DruidHttpSettings.tsx
+++ b/public/app/plugins/datasource/grafadruid-druid-datasource/configuration/ConnectionSettings/DruidHttpSettings.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { ChangeEvent } from 'react';
 
-import { LegacyForms, FieldSet, Field, Switch } from '@grafana/ui';
+import { LegacyForms, FieldSet, Field, Switch, TagsInput, InlineFormLabel } from '@grafana/ui';
 
 import { ConnectionSettingsProps } from './types';
 
@@ -92,6 +92,19 @@ export const DruidHttpSettings = (props: ConnectionSettingsProps) => {
           <Switch value={settings.skipTls} name="skipTls" onChange={onSettingChange} />
         </Field>
       )}
+      <div className="gf-form">
+        <InlineFormLabel
+          width={11}
+          tooltip="Grafana proxy deletes forwarded cookies by default. Specify cookies by name that should be forwarded to the data source."
+        >
+          Allowed cookies
+        </InlineFormLabel>
+        <TagsInput
+          tags={options.jsonData?.keepCookies || []}
+          width={40}
+          onChange={(cookies) => onOptionsChange({ ...options, jsonData: { keepCookies: cookies } })}
+        />
+      </div>
     </FieldSet>
   );
 };

--- a/public/app/plugins/datasource/grafadruid-druid-datasource/configuration/ConnectionSettings/types.ts
+++ b/public/app/plugins/datasource/grafadruid-druid-datasource/configuration/ConnectionSettings/types.ts
@@ -16,6 +16,9 @@ export interface ConnectionSettingsOptions {
   settings: ConnectionSettings;
   secretSettings: ConnectionSecretSettings;
   secretSettingsFields: KeyValue<boolean>;
+  jsonData?: {
+    keepCookies?: string[];
+  },
 }
 
 export interface ConnectionSettingsProps {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to specify allowed cookies for forwarding to the data source in Druid connection settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->