### PR TITLE
removed time range option under 24hrs

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/options.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/options.ts
@@ -1,13 +1,13 @@
 import { SelectableValue, TimeOption } from '@grafana/data';
 
 export const quickOptions: TimeOption[] = [
-  { from: 'now-5m', to: 'now', display: 'Last 5 minutes' },
-  { from: 'now-15m', to: 'now', display: 'Last 15 minutes' },
-  { from: 'now-30m', to: 'now', display: 'Last 30 minutes' },
-  { from: 'now-1h', to: 'now', display: 'Last 1 hour' },
-  { from: 'now-3h', to: 'now', display: 'Last 3 hours' },
-  { from: 'now-6h', to: 'now', display: 'Last 6 hours' },
-  { from: 'now-12h', to: 'now', display: 'Last 12 hours' },
+  // { from: 'now-5m', to: 'now', display: 'Last 5 minutes' },
+  // { from: 'now-15m', to: 'now', display: 'Last 15 minutes' },
+  // { from: 'now-30m', to: 'now', display: 'Last 30 minutes' },
+  // { from: 'now-1h', to: 'now', display: 'Last 1 hour' },
+  // { from: 'now-3h', to: 'now', display: 'Last 3 hours' },
+  // { from: 'now-6h', to: 'now', display: 'Last 6 hours' },
+  // { from: 'now-12h', to: 'now', display: 'Last 12 hours' },
   { from: 'now-24h', to: 'now', display: 'Last 24 hours' },
   { from: 'now-2d', to: 'now', display: 'Last 2 days' },
   { from: 'now-7d', to: 'now', display: 'Last 7 days' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed several short-duration quick time range options from the date/time picker interface. Longer and other existing time ranges remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->