### PR TITLE
Add CodeRabbit render context token support

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -34,6 +34,13 @@ func ProvideService(cfg *setting.Cfg) *Service {
 		logger:            logger,
 		rendererAuthToken: cfg.RendererAuthToken,
 	}
+
+	if cfg.RendererAuthToken != "" && cfg.RendererAuthToken != "-" {
+		logger.Info("CodeRabbit renderer auth token configured")
+	} else {
+		logger.Warn("CodeRabbit renderer auth token NOT configured — cr_render_context_token decoding will fail")
+	}
+
 	s.im = datasource.NewInstanceManager(s.newInstanceSettings())
 
 	// Initialize CodeRabbit organization database connection if configured

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -24,18 +24,20 @@ import (
 )
 
 const (
-	CR_POSTGRES_URL = "GF_CR_POSTGRES_URL"
+	CR_POSTGRES_URL                   = "GF_CR_POSTGRES_URL"
+	CR_RENDERER_AUTH_TOKEN_JWT_SECRET = "GF_CR_RENDERER_AUTH_TOKEN_JWT_SECRET"
 )
 
 func ProvideService(cfg *setting.Cfg) *Service {
 	logger := backend.NewLoggerWith("logger", "tsdb.postgres")
 	s := &Service{
-		tlsManager:        newTLSManager(logger, cfg.DataPath),
-		logger:            logger,
-		rendererAuthToken: cfg.RendererAuthToken,
+		tlsManager: newTLSManager(logger, cfg.DataPath),
+		logger:     logger,
+		// To decode cr_render_context_token while taking screenshot of dashboard
+		rendererAuthToken: os.Getenv(CR_RENDERER_AUTH_TOKEN_JWT_SECRET),
 	}
 
-	if cfg.RendererAuthToken != "" && cfg.RendererAuthToken != "-" {
+	if s.rendererAuthToken != "" && s.rendererAuthToken != "-" {
 		logger.Info("CodeRabbit renderer auth token configured")
 	} else {
 		logger.Warn("CodeRabbit renderer auth token NOT configured — cr_render_context_token decoding will fail")

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -30,8 +30,9 @@ const (
 func ProvideService(cfg *setting.Cfg) *Service {
 	logger := backend.NewLoggerWith("logger", "tsdb.postgres")
 	s := &Service{
-		tlsManager: newTLSManager(logger, cfg.DataPath),
-		logger:     logger,
+		tlsManager:        newTLSManager(logger, cfg.DataPath),
+		logger:            logger,
+		rendererAuthToken: cfg.RendererAuthToken,
 	}
 	s.im = datasource.NewInstanceManager(s.newInstanceSettings())
 
@@ -64,10 +65,11 @@ func ProvideService(cfg *setting.Cfg) *Service {
 }
 
 type Service struct {
-	tlsManager tlsSettingsProvider
-	im         instancemgmt.InstanceManager
-	logger     log.Logger
-	crDB       *sql.DB // CodeRabbit organization database connection
+	tlsManager        tlsSettingsProvider
+	im                instancemgmt.InstanceManager
+	logger            log.Logger
+	crDB              *sql.DB // CodeRabbit organization database connection
+	rendererAuthToken string
 }
 
 func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext) (*sqleng.DataSourceHandler, error) {
@@ -87,11 +89,12 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	return dsInfo.QueryData(ctx, req)
 }
 
-func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit int64, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger, settings backend.DataSourceInstanceSettings, crDB *sql.DB) (*sql.DB, *sqleng.DataSourceHandler, error) {
+func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit int64, dsInfo sqleng.DataSourceInfo, cnnstr string, logger log.Logger, settings backend.DataSourceInstanceSettings, crDB *sql.DB, rendererAuthToken string) (*sql.DB, *sqleng.DataSourceHandler, error) {
 	config := sqleng.DataPluginConfiguration{
 		DSInfo:            dsInfo,
 		MetricColumnTypes: []string{"UNKNOWN", "TEXT", "VARCHAR", "CHAR"},
 		RowLimit:          rowLimit,
+		RendererAuthToken: rendererAuthToken,
 	}
 
 	queryResultTransformer := postgresQueryResultTransformer{}
@@ -191,7 +194,7 @@ func (s *Service) newInstanceSettings() datasource.InstanceFactoryFunc {
 			return nil, err
 		}
 
-		_, handler, err := newPostgres(ctx, userFacingDefaultError, sqlCfg.RowLimit, dsInfo, cnnstr, logger, settings, s.crDB)
+		_, handler, err := newPostgres(ctx, userFacingDefaultError, sqlCfg.RowLimit, dsInfo, cnnstr, logger, settings, s.crDB, s.rendererAuthToken)
 
 		if err != nil {
 			logger.Error("Failed connecting to Postgres", "err", err)

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -166,7 +166,7 @@ func TestIntegrationPostgresSnapshots(t *testing.T) {
 
 			cnnstr := getCnnStr()
 
-			db, handler, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{})
+			db, handler, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{}, "")
 
 			t.Cleanup((func() {
 				_, err := db.Exec("DROP TABLE tbl")

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_test.go
@@ -218,7 +218,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 	cnnstr := postgresTestDBConnString()
 
-	db, exe, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{})
+	db, exe, err := newPostgres(context.Background(), "error", 10000, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{}, "")
 
 	require.NoError(t, err)
 
@@ -1272,7 +1272,7 @@ func TestIntegrationPostgres(t *testing.T) {
 
 		t.Run("When row limit set to 1", func(t *testing.T) {
 			dsInfo := sqleng.DataSourceInfo{}
-			_, handler, err := newPostgres(context.Background(), "error", 1, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{})
+			_, handler, err := newPostgres(context.Background(), "error", 1, dsInfo, cnnstr, logger, backend.DataSourceInstanceSettings{}, &sql.DB{}, "")
 
 			require.NoError(t, err)
 

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"runtime/debug"
@@ -15,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/gtime"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -25,10 +28,12 @@ import (
 
 // MetaKeyExecutedQueryString is the key where the executed query should get stored
 const (
-	MetaKeyExecutedQueryString   = "executedQueryString"
-	headerCodeRabbitOrg          = "X-CodeRabbit-Org-Id"
-	headerCodeRabbitSelfHostedId = "X-CodeRabbit-Self-Hosted-Instance-Id"
-	CR_POSTGRES_URL              = "GF_CR_POSTGRES_URL"
+	MetaKeyExecutedQueryString        = "executedQueryString"
+	headerCodeRabbitOrg               = "X-CodeRabbit-Org-Id"
+	headerCodeRabbitSelfHostedId      = "X-CodeRabbit-Self-Hosted-Instance-Id"
+	headerCodeRabbitRenderContext     = "X-CodeRabbit-Render-Context-Token"
+	queryCodeRabbitRenderContextToken = "cr_render_context_token"
+	CR_POSTGRES_URL                   = "GF_CR_POSTGRES_URL"
 )
 
 // SQLMacroEngine interpolates macros into sql. It takes in the Query to have access to query context and
@@ -83,6 +88,7 @@ type DataPluginConfiguration struct {
 	TimeColumnNames   []string
 	MetricColumnTypes []string
 	RowLimit          int64
+	RendererAuthToken string
 }
 
 type DataSourceHandler struct {
@@ -95,6 +101,7 @@ type DataSourceHandler struct {
 	dsInfo                 DataSourceInfo
 	rowLimit               int64
 	userError              string
+	rendererAuthToken      string
 }
 
 type QueryJson struct {
@@ -130,6 +137,7 @@ func NewQueryDataHandler(userFacingDefaultError string, db *sql.DB, config DataP
 		dsInfo:                 config.DSInfo,
 		rowLimit:               config.RowLimit,
 		userError:              userFacingDefaultError,
+		rendererAuthToken:      config.RendererAuthToken,
 	}
 
 	if len(config.TimeColumnNames) > 0 {
@@ -209,26 +217,127 @@ func (e *DataSourceHandler) QueryData(ctx context.Context, req *backend.QueryDat
 	return result, nil
 }
 
-func (e *DataSourceHandler) findCodeRabbitOrgId(ctx context.Context) string {
-	codeRabbitOrgId := ""
-	reqCtx := contexthandler.FromContext(ctx)
-	if reqCtx != nil && reqCtx.Req != nil {
-		codeRabbitOrgId = reqCtx.Req.Header.Get(headerCodeRabbitOrg)
-	} else {
-		e.log.Debug("Request context or request is nil, cannot extract CodeRabbit Org ID from headers")
-	}
-	return codeRabbitOrgId
+type codeRabbitRenderContextClaims struct {
+	OrgID                     string `json:"orgId,omitempty"`
+	OrgIDSnake                string `json:"org_id,omitempty"`
+	SelfHostedInstanceID      string `json:"selfHostedInstanceId,omitempty"`
+	SelfHostedInstanceIDSnake string `json:"self_hosted_instance_id,omitempty"`
+	jwt.RegisteredClaims
 }
 
-func (e *DataSourceHandler) findCodeRabbitSelfHostedId(ctx context.Context) string {
-	codeRabbitSelfHostedId := ""
+type codeRabbitRenderContext struct {
+	orgID                string
+	selfHostedInstanceID string
+}
+
+func (e *DataSourceHandler) findCodeRabbitIdentifiers(ctx context.Context) codeRabbitRenderContext {
 	reqCtx := contexthandler.FromContext(ctx)
 	if reqCtx != nil && reqCtx.Req != nil {
-		codeRabbitSelfHostedId = reqCtx.Req.Header.Get(headerCodeRabbitSelfHostedId)
-	} else {
-		e.log.Debug("Request context or request is nil, cannot extract CodeRabbit Self-Hosted Instance ID from headers")
+		return e.findCodeRabbitIdentifiersFromRequest(reqCtx.Req)
 	}
-	return codeRabbitSelfHostedId
+
+	e.log.Debug("Request context or request is nil, cannot extract CodeRabbit identifiers")
+	return codeRabbitRenderContext{}
+}
+
+func (e *DataSourceHandler) findCodeRabbitIdentifiersFromRequest(req *http.Request) codeRabbitRenderContext {
+	codeRabbitOrgID := req.Header.Get(headerCodeRabbitOrg)
+	codeRabbitSelfHostedID := req.Header.Get(headerCodeRabbitSelfHostedId)
+	if codeRabbitOrgID != "" || codeRabbitSelfHostedID != "" {
+		return codeRabbitRenderContext{
+			orgID:                codeRabbitOrgID,
+			selfHostedInstanceID: codeRabbitSelfHostedID,
+		}
+	}
+
+	renderContextToken := findCodeRabbitRenderContextToken(req)
+	if renderContextToken == "" {
+		return codeRabbitRenderContext{}
+	}
+
+	renderContext, err := decodeCodeRabbitRenderContextToken(renderContextToken, e.rendererAuthToken)
+	if err != nil {
+		e.log.Warn("Failed to decode CodeRabbit render context token", "err", err)
+		return codeRabbitRenderContext{}
+	}
+
+	return renderContext
+}
+
+func findCodeRabbitRenderContextToken(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+
+	if renderContextToken := req.Header.Get(headerCodeRabbitRenderContext); renderContextToken != "" {
+		return renderContextToken
+	}
+
+	if req.URL != nil {
+		if renderContextToken := req.URL.Query().Get(queryCodeRabbitRenderContextToken); renderContextToken != "" {
+			return renderContextToken
+		}
+	}
+
+	referer := req.Referer()
+	if referer == "" {
+		return ""
+	}
+
+	refererURL, err := url.Parse(referer)
+	if err != nil {
+		return ""
+	}
+
+	return refererURL.Query().Get(queryCodeRabbitRenderContextToken)
+}
+
+func decodeCodeRabbitRenderContextToken(renderContextToken string, rendererAuthToken string) (codeRabbitRenderContext, error) {
+	if rendererAuthToken == "" {
+		return codeRabbitRenderContext{}, errors.New("renderer auth token is not configured")
+	}
+
+	claims := new(codeRabbitRenderContextClaims)
+	token, err := jwt.ParseWithClaims(renderContextToken, claims, func(_ *jwt.Token) (any, error) {
+		return []byte(rendererAuthToken), nil
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Alg()}))
+	if err != nil {
+		return codeRabbitRenderContext{}, err
+	}
+
+	if token == nil || !token.Valid {
+		return codeRabbitRenderContext{}, errors.New("invalid render context token")
+	}
+
+	if claims.ExpiresAt == nil {
+		return codeRabbitRenderContext{}, errors.New("render context token must include an expiration")
+	}
+
+	codeRabbitOrgID := strings.TrimSpace(firstNonEmpty(claims.OrgID, claims.OrgIDSnake))
+	codeRabbitSelfHostedID := strings.TrimSpace(firstNonEmpty(claims.SelfHostedInstanceID, claims.SelfHostedInstanceIDSnake))
+
+	if codeRabbitOrgID == "" && codeRabbitSelfHostedID == "" {
+		return codeRabbitRenderContext{}, errors.New("render context token must include an orgId or selfHostedInstanceId")
+	}
+
+	if codeRabbitOrgID != "" && codeRabbitSelfHostedID != "" {
+		return codeRabbitRenderContext{}, errors.New("render context token cannot include both orgId and selfHostedInstanceId")
+	}
+
+	return codeRabbitRenderContext{
+		orgID:                codeRabbitOrgID,
+		selfHostedInstanceID: codeRabbitSelfHostedID,
+	}, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
 }
 
 func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitGroup, queryContext context.Context,
@@ -281,8 +390,9 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 		return
 	}
 
-	codeRabbitOrgId := e.findCodeRabbitOrgId(queryContext)
-	codeRabbitSelfHostedId := e.findCodeRabbitSelfHostedId(queryContext)
+	codeRabbitContext := e.findCodeRabbitIdentifiers(queryContext)
+	codeRabbitOrgId := codeRabbitContext.orgID
+	codeRabbitSelfHostedId := codeRabbitContext.selfHostedInstanceID
 	queryDB := e.db
 
 	var (

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -236,7 +236,7 @@ func (e *DataSourceHandler) findCodeRabbitIdentifiers(ctx context.Context) codeR
 		return e.findCodeRabbitIdentifiersFromRequest(reqCtx.Req)
 	}
 
-	e.log.Debug("Request context or request is nil, cannot extract CodeRabbit identifiers")
+	e.log.Warn("Request context or request is nil, cannot extract CodeRabbit identifiers from context")
 	return codeRabbitRenderContext{}
 }
 
@@ -252,15 +252,28 @@ func (e *DataSourceHandler) findCodeRabbitIdentifiersFromRequest(req *http.Reque
 
 	renderContextToken := findCodeRabbitRenderContextToken(req)
 	if renderContextToken == "" {
+		urlStr := ""
+		if req.URL != nil {
+			urlStr = req.URL.String()
+		}
+		e.log.Info("No CodeRabbit render context token found",
+			"url", urlStr,
+			"referer", req.Header.Get("Referer"),
+			"has_cr_header", req.Header.Get(headerCodeRabbitRenderContext) != "",
+		)
 		return codeRabbitRenderContext{}
 	}
 
 	renderContext, err := decodeCodeRabbitRenderContextToken(renderContextToken, e.rendererAuthToken)
 	if err != nil {
-		e.log.Warn("Failed to decode CodeRabbit render context token", "err", err)
+		e.log.Warn("Failed to decode CodeRabbit render context token",
+			"err", err,
+			"rendererAuthTokenEmpty", e.rendererAuthToken == "",
+		)
 		return codeRabbitRenderContext{}
 	}
 
+	e.log.Info("Decoded CodeRabbit render context token", "orgID", renderContext.orgID)
 	return renderContext
 }
 

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
@@ -1,11 +1,16 @@
 package sqleng
 
 import (
+	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
@@ -13,6 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 func Pointer[T any](v T) *T { return &v }
@@ -423,6 +431,112 @@ func TestSQLEngine(t *testing.T) {
 		assert.Equal(t, err, resultErr)
 		assert.ErrorIs(t, err, resultErr)
 	})
+}
+
+func TestCodeRabbitRenderContextToken(t *testing.T) {
+	const rendererAuthToken = "renderer-token"
+
+	t.Run("prefers CodeRabbit headers when present", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/ds/query", nil)
+		req.Header.Set(headerCodeRabbitOrg, "org-from-header")
+
+		handler := DataSourceHandler{
+			log:               backend.NewLoggerWith("logger", "test"),
+			rendererAuthToken: rendererAuthToken,
+		}
+		reqCtx := &contextmodel.ReqContext{Context: &web.Context{Req: req}}
+		ctx := ctxkey.Set(context.Background(), reqCtx)
+
+		renderContext := handler.findCodeRabbitIdentifiers(ctx)
+		require.Equal(t, "org-from-header", renderContext.orgID)
+		require.Empty(t, renderContext.selfHostedInstanceID)
+	})
+
+	t.Run("decodes org ID from render context token in referer", func(t *testing.T) {
+		token := signCodeRabbitRenderContextToken(t, rendererAuthToken, codeRabbitRenderContextClaims{
+			OrgID: "org-from-token",
+		})
+		refererURL := url.URL{
+			Scheme:   "http",
+			Host:     "grafana.local",
+			Path:     "/d/summary/summary",
+			RawQuery: url.Values{queryCodeRabbitRenderContextToken: []string{token}}.Encode(),
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/ds/query", nil)
+		req.Header.Set("Referer", refererURL.String())
+
+		handler := DataSourceHandler{
+			log:               backend.NewLoggerWith("logger", "test"),
+			rendererAuthToken: rendererAuthToken,
+		}
+
+		renderContext := handler.findCodeRabbitIdentifiersFromRequest(req)
+		require.Equal(t, "org-from-token", renderContext.orgID)
+		require.Empty(t, renderContext.selfHostedInstanceID)
+	})
+
+	t.Run("decodes self-hosted ID from render context token in query params", func(t *testing.T) {
+		token := signCodeRabbitRenderContextToken(t, rendererAuthToken, codeRabbitRenderContextClaims{
+			SelfHostedInstanceID: "self-hosted-from-token",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/ds/query?"+url.Values{queryCodeRabbitRenderContextToken: []string{token}}.Encode(), nil)
+
+		handler := DataSourceHandler{
+			log:               backend.NewLoggerWith("logger", "test"),
+			rendererAuthToken: rendererAuthToken,
+		}
+
+		renderContext := handler.findCodeRabbitIdentifiersFromRequest(req)
+		require.Empty(t, renderContext.orgID)
+		require.Equal(t, "self-hosted-from-token", renderContext.selfHostedInstanceID)
+	})
+
+	t.Run("ignores render context tokens signed with the wrong renderer token", func(t *testing.T) {
+		token := signCodeRabbitRenderContextToken(t, "wrong-token", codeRabbitRenderContextClaims{
+			OrgID: "org-from-token",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/ds/query?"+url.Values{queryCodeRabbitRenderContextToken: []string{token}}.Encode(), nil)
+
+		handler := DataSourceHandler{
+			log:               backend.NewLoggerWith("logger", "test"),
+			rendererAuthToken: rendererAuthToken,
+		}
+
+		renderContext := handler.findCodeRabbitIdentifiersFromRequest(req)
+		require.Empty(t, renderContext.orgID)
+		require.Empty(t, renderContext.selfHostedInstanceID)
+	})
+
+	t.Run("rejects render context tokens with both identifiers", func(t *testing.T) {
+		token := signCodeRabbitRenderContextToken(t, rendererAuthToken, codeRabbitRenderContextClaims{
+			OrgID:                "org-from-token",
+			SelfHostedInstanceID: "self-hosted-from-token",
+		})
+		req := httptest.NewRequest(http.MethodPost, "/api/ds/query?"+url.Values{queryCodeRabbitRenderContextToken: []string{token}}.Encode(), nil)
+
+		handler := DataSourceHandler{
+			log:               backend.NewLoggerWith("logger", "test"),
+			rendererAuthToken: rendererAuthToken,
+		}
+
+		renderContext := handler.findCodeRabbitIdentifiersFromRequest(req)
+		require.Empty(t, renderContext.orgID)
+		require.Empty(t, renderContext.selfHostedInstanceID)
+	})
+}
+
+func signCodeRabbitRenderContextToken(t *testing.T, rendererAuthToken string, claims codeRabbitRenderContextClaims) string {
+	t.Helper()
+
+	if claims.ExpiresAt == nil {
+		claims.ExpiresAt = jwt.NewNumericDate(time.Now().UTC().Add(time.Minute))
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)
+	signedToken, err := token.SignedString([]byte(rendererAuthToken))
+	require.NoError(t, err)
+
+	return signedToken
 }
 
 type testQueryResultTransformer struct {


### PR DESCRIPTION
## Summary
- Decode a short-lived CodeRabbit render context JWT from request headers, query params, or dashboard referer.
- Accept either orgId or selfHostedInstanceId and use Grafana rendering renderer_token as the HS512 signing secret.
- Wire renderer_token into the PostgreSQL datasource handler and cover header/referer/query behavior with tests.

## Test plan
- go test ./pkg/tsdb/grafana-postgresql-datasource/...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for extracting render-context from signed tokens so PostgreSQL queries can run with organization or instance context.
  * Datasource now honors a configured renderer auth token and logs when it is present or missing.

* **Tests**
  * Expanded tests covering render-context token handling, JWT decoding, claim validation, and related behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/grafana/pull/213)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->