### PR TITLE
Fix dev grafana image pull failing with mount options too long

### DIFF
--- a/.github/workflows/deploy-cloud-run-grafana.yaml
+++ b/.github/workflows/deploy-cloud-run-grafana.yaml
@@ -21,10 +21,6 @@ jobs:
           sudo docker system prune -af || true
           df -h
 
-      - uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GOOGLECLOUDSA }}
-
       - uses: docker/setup-buildx-action@v3
 
       # - name: Cache Docker layers
@@ -34,15 +30,26 @@ jobs:
       #     key: ${{ runner.os }}-${{ github.workflow }}-${{ github.sha }}
       #     restore-keys: ${{ runner.os }}-${{ github.workflow }}-
 
-      - run: gcloud auth configure-docker
-
-      - uses: docker/build-push-action@v5
+      - name: Build image once
+        uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
-          tags: gcr.io/coderabbit/grafana:latest
+          push: false
+          load: true
+          tags: grafana:latest
           # cache-from: type=local,src=/tmp/.buildx-cache
           # cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GOOGLECLOUDSA }}
+
+      - run: gcloud auth configure-docker
+
+      - name: Push image to dev
+        run: |
+          docker tag grafana:latest gcr.io/coderabbit/grafana:latest
+          docker push gcr.io/coderabbit/grafana:latest
 
       # - name: Move Docker cache
       #   run: |

--- a/.github/workflows/deploy-cloud-run-grafana.yaml
+++ b/.github/workflows/deploy-cloud-run-grafana.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           credentials_json: ${{ secrets.GOOGLECLOUDSA }}
 
-      - run: gcloud auth configure-docker
+      - run: gcloud auth configure-docker gcr.io --quiet
 
       - name: Push image to dev
         run: |


### PR DESCRIPTION
## Summary

- Mirror the prod workflow's build-then-push pattern in `.github/workflows/deploy-cloud-run-grafana.yaml` so the dev tag is published as a flat single-arch manifest.
- `docker/build-push-action@v5` with `push: true` attaches SLSA provenance + SBOM attestations by default; the extra `unknown/unknown` attestation manifest bloats containerd's overlay `lowerdir=` past `PAGE_SIZE`, causing `mount options is too long` (EINVAL) when `docker compose up grafana` pulls `gcr.io/coderabbit/grafana:latest`.
- Now: buildx builds locally (`push: false, load: true` → `grafana:latest`), then `docker tag` + `docker push` ships to `gcr.io/coderabbit/grafana:latest`. Dev keeps its existing `GOOGLECLOUDSA` JSON-credentials auth; prod workflow is untouched.

## Test plan

- [ ] Workflow runs green on the next push to `coderabbit_micro_frontend`.
- [ ] `docker buildx imagetools inspect gcr.io/coderabbit/grafana:latest` reports a single `linux/amd64` manifest — no attestation-manifest / unknown/unknown entries, no manifest list.
- [ ] From `coderabbitai/mono` with `image: gcr.io/coderabbit/grafana:latest` in `compose.yaml`: `docker compose pull grafana` then `docker compose up -d --force-recreate grafana` starts the container with no "mount options is too long" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Grafana deployment workflow: build image locally first, then authenticate and tag/push to the registry—streamlines build/push ordering and consolidates authentication steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/grafana/pull/215)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->