### PR TITLE
Fix table scroll height for manual pagination

### DIFF
--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
@@ -17,7 +17,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       display: flex;
       flex-direction: column;
       min-width: 100%;
-      min-height: 100%;
       border: 1px solid ${borderColor};
       border-radius: ${theme.shape.radius.default};
       background: ${theme.colors.background.primary};
@@ -59,8 +58,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       gap: ${theme.spacing(0.5)};
       flex-wrap: nowrap;
       flex: auto;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      overflow: visible;
       white-space: nowrap;
       color: ${theme.colors.text.secondary};
       font-size: ${theme.typography.bodySmall.fontSize};
@@ -134,7 +132,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       box-sizing: border-box;
       overflow-x: hidden;
       overflow-y: hidden;
-      margin-top: auto;
       border-right: 1px solid ${borderColor};
       scrollbar-width: none;
 

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
@@ -7,6 +7,9 @@ import { GrafanaTheme2 } from '@grafana/data';
  */
 export const getStyles = (theme: GrafanaTheme2) => {
   const borderColor = theme.colors.border.weak;
+  const controlBackground = theme.colors.background.secondary;
+  const controlBorder = theme.colors.border.medium;
+  const controlHoverBackground = theme.colors.action.hover;
 
   return {
     root: css`
@@ -124,11 +127,10 @@ export const getStyles = (theme: GrafanaTheme2) => {
       justify-content: flex-end;
       width: 100%;
       max-width: 100%;
-      padding: ${theme.spacing(0, 1)};
-      gap: ${theme.spacing(1)};
+      padding: ${theme.spacing(1)};
       align-items: center;
       border-top: 1px solid ${borderColor};
-      min-height: ${theme.spacing(4.75)};
+      min-height: ${theme.spacing(5.25)};
       box-sizing: border-box;
       overflow-x: hidden;
       overflow-y: hidden;
@@ -140,11 +142,99 @@ export const getStyles = (theme: GrafanaTheme2) => {
         display: none;
       }
     `,
-    pagination: css`
-      float: none;
-      li {
-        margin-bottom: 0;
+    paginationControl: css`
+      display: inline-flex;
+      align-items: center;
+      min-width: 0;
+      height: 36px;
+      border-radius: ${theme.shape.radius.default};
+      border: 1px solid ${controlBorder};
+      background: ${controlBackground};
+      overflow: hidden;
+    `,
+    paginationPageSizeSection: css`
+      display: flex;
+      align-items: center;
+      height: 36px;
+      padding: 0 ${theme.spacing(1.5)};
+      gap: ${theme.spacing(1)};
+    `,
+    paginationPageSize: css`
+      display: inline-flex;
+      align-items: center;
+      gap: ${theme.spacing(0.5)};
+      height: 24px;
+      padding: 0 ${theme.spacing(0.75)};
+      border: 0;
+      border-radius: ${theme.shape.radius.default};
+      background: transparent;
+      color: ${theme.colors.text.primary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      font-weight: ${theme.typography.fontWeightRegular};
+      font-variant-numeric: tabular-nums;
+      line-height: 20px;
+      cursor: pointer;
+
+      &:hover,
+      &[aria-expanded='true'] {
+        background: ${controlHoverBackground};
       }
+    `,
+    paginationDivider: css`
+      align-self: stretch;
+      width: 1px;
+      background: ${controlBorder};
+    `,
+    paginationNavigation: css`
+      display: flex;
+      align-items: center;
+      height: 36px;
+      gap: 2px;
+      padding: 0 ${theme.spacing(0.75)};
+    `,
+    paginationButton: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      border: 0;
+      border-radius: ${theme.shape.radius.default};
+      background: transparent;
+      color: ${theme.colors.text.secondary};
+      cursor: pointer;
+      transition:
+        background-color 150ms ease,
+        color 150ms ease;
+
+      &:hover:not(:disabled) {
+        background: ${controlHoverBackground};
+        color: ${theme.colors.text.primary};
+      }
+
+      &:focus-visible {
+        outline: 2px solid ${theme.colors.primary.border};
+        outline-offset: 1px;
+      }
+
+      &:disabled {
+        color: ${theme.colors.text.disabled};
+        cursor: default;
+        pointer-events: none;
+      }
+    `,
+    paginationPageLabel: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 ${theme.spacing(1)};
+      color: ${theme.colors.text.secondary};
+      font-size: ${theme.typography.bodySmall.fontSize};
+      font-variant-numeric: tabular-nums;
+      line-height: 20px;
+      white-space: nowrap;
+      user-select: none;
     `,
     drawerTitle: css`
       padding: ${theme.spacing(2, 2, 0, 2)};

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.test.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.test.tsx
@@ -1,15 +1,25 @@
-import { createTheme, EventBusSrv } from '@grafana/data';
 import { createRow, Table as TableInstance } from '@tanstack/react-table';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { getJestSelectors } from '@volkovlabs/jest-selectors';
 import React, { useRef } from 'react';
 
+import { createTheme, EventBusSrv } from '@grafana/data';
 import { ACTIONS_COLUMN_ID, ROW_HIGHLIGHT_STATE_KEY } from 'app/plugins/panel/volkovlabs-table-panel/constants';
-import { ColumnEditorType, ColumnPinDirection, Pagination, ScrollToRowPosition } from 'app/plugins/panel/volkovlabs-table-panel/types';
-import { createColumnAccessorFn, createColumnConfig, createColumnMeta, createRowHighlightConfig } from 'app/plugins/panel/volkovlabs-table-panel/utils';
+import {
+  ColumnEditorType,
+  ColumnPinDirection,
+  Pagination,
+  ScrollToRowPosition,
+} from 'app/plugins/panel/volkovlabs-table-panel/types';
+import {
+  createColumnAccessorFn,
+  createColumnConfig,
+  createColumnMeta,
+  createRowHighlightConfig,
+} from 'app/plugins/panel/volkovlabs-table-panel/utils';
 
-import { useAddData } from './hooks';
 import { Table, testIds } from './Table';
+import { useAddData } from './hooks';
 
 type Props = React.ComponentProps<typeof Table>;
 
@@ -486,13 +496,12 @@ describe('Table', () => {
 
     await act(async () => render(getComponent({ pagination })));
 
-    expect(selectors.fieldPageNumber()).toBeInTheDocument();
-    expect(selectors.fieldPageNumber()).toHaveValue('1');
+    expect(screen.getByText('1 / 10')).toBeInTheDocument();
 
-    fireEvent.change(selectors.fieldPageNumber(), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
 
     expect(onChange).toHaveBeenCalledWith({
-      pageIndex: 2,
+      pageIndex: 1,
       pageSize: 10,
     });
   });

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
@@ -21,7 +21,7 @@ import { get } from 'lodash';
 import React, { CSSProperties, RefObject, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DataFrame, EventBus, GrafanaTheme2, InterpolateFunction } from '@grafana/data';
-import { Button, ConfirmModal, Drawer, Pagination, useStyles2, useTheme2 } from '@grafana/ui';
+import { Button, ConfirmModal, Drawer, Icon, useStyles2, useTheme2 } from '@grafana/ui';
 import { ButtonSelect } from 'app/plugins/panel/volkovlabs-table-panel/components';
 import {
   PAGE_SIZE_OPTIONS,
@@ -554,6 +554,17 @@ export const Table = <TData,>({
   const virtualRows = rowVirtualizer.getVirtualItems();
 
   /**
+   * Pagination pages
+   */
+  const numberOfPages = useMemo(() => {
+    const pageCount = pagination.isManual
+      ? Math.ceil(pagination.total / pagination.value.pageSize)
+      : table.getPageCount();
+
+    return Math.max(1, pageCount);
+  }, [pagination.isManual, pagination.total, pagination.value.pageSize, table]);
+
+  /**
    * Is Footer Visible
    */
   const isFooterVisible = useMemo(() => {
@@ -767,34 +778,64 @@ export const Table = <TData,>({
         </table>
       </div>
       {pagination.isEnabled && (
-        <div className={styles.paginationRow} ref={paginationRef} {...testIds.pagination.apply()}>
-          <Pagination
-            currentPage={pagination.value.pageIndex + 1}
-            numberOfPages={
-              pagination.isManual ? Math.ceil(pagination.total / pagination.value.pageSize) : table.getPageCount()
-            }
-            onNavigate={(pageNumber) => {
-              pagination.onChange({
-                ...pagination.value,
-                pageIndex: pageNumber - 1,
-              });
-            }}
-            className={styles.pagination}
-            showSmallVersion={width <= 200}
-            {...testIds.fieldPageNumber.apply()}
-          />
-          <ButtonSelect
-            options={PAGE_SIZE_OPTIONS}
-            value={{ value: pagination.value.pageSize }}
-            onChange={(event) => {
-              pagination.onChange({
-                pageIndex: 0,
-                pageSize: event.value!,
-              });
-            }}
-            {...testIds.fieldPageSize.apply()}
-          />
-        </div>
+        <nav
+          className={styles.paginationRow}
+          ref={paginationRef}
+          aria-label="Pagination"
+          {...testIds.pagination.apply()}
+        >
+          <div className={styles.paginationControl}>
+            <div className={styles.paginationPageSizeSection}>
+              <ButtonSelect
+                className={styles.paginationPageSize}
+                options={PAGE_SIZE_OPTIONS}
+                value={{ value: pagination.value.pageSize }}
+                onChange={(event) => {
+                  pagination.onChange({
+                    pageIndex: 0,
+                    pageSize: event.value!,
+                  });
+                }}
+                {...testIds.fieldPageSize.apply()}
+              />
+            </div>
+            <div className={styles.paginationDivider} />
+            <div className={styles.paginationNavigation}>
+              <button
+                type="button"
+                aria-label="Previous page"
+                className={styles.paginationButton}
+                disabled={pagination.value.pageIndex === 0}
+                onClick={() => {
+                  pagination.onChange({
+                    ...pagination.value,
+                    pageIndex: Math.max(0, pagination.value.pageIndex - 1),
+                  });
+                }}
+                {...testIds.fieldPageNumber.apply()}
+              >
+                <Icon name="angle-left" size="md" />
+              </button>
+              <span className={styles.paginationPageLabel}>
+                {pagination.value.pageIndex + 1} / {numberOfPages}
+              </span>
+              <button
+                type="button"
+                aria-label="Next page"
+                className={styles.paginationButton}
+                disabled={pagination.value.pageIndex >= numberOfPages - 1}
+                onClick={() => {
+                  pagination.onChange({
+                    ...pagination.value,
+                    pageIndex: Math.min(numberOfPages - 1, pagination.value.pageIndex + 1),
+                  });
+                }}
+              >
+                <Icon name="angle-right" size="md" />
+              </button>
+            </div>
+          </div>
+        </nav>
       )}
       {!!deleteData.row && (
         <ConfirmModal

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
@@ -515,6 +515,7 @@ export const Table = <TData,>({
     getPaginationRowModel: getPaginationRowModel(),
     onPaginationChange: pagination.onChange,
     manualPagination: pagination.isManual,
+    pageCount: pagination.isManual ? Math.max(1, Math.ceil(pagination.total / pagination.value.pageSize)) : undefined,
 
     /**
      * Debug

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx
@@ -535,6 +535,12 @@ export const Table = <TData,>({
   const { rows } = table.getRowModel();
 
   /**
+   * Render all rows when the loaded page contains fewer rows than the selected page size.
+   * Otherwise the virtualizer can leave a visible spacer inside the fixed-height tbody.
+   */
+  const shouldRenderAllRows = pagination.isEnabled && rows.length < pagination.value.pageSize;
+
+  /**
    * Row Virtualizer
    * Options description - https://tanstack.com/virtual/v3/docs/api/virtualizer
    */
@@ -544,7 +550,7 @@ export const Table = <TData,>({
     getItemKey: useCallback((index: number) => rows[index].id, [rows]),
     estimateSize: useCallback(() => 37, []),
     measureElement: useCallback((el: HTMLElement | HTMLTableRowElement) => el.offsetHeight, []),
-    overscan: 10,
+    overscan: shouldRenderAllRows ? rows.length : 10,
     scrollPaddingEnd: scrollPaddingEnd,
   });
 
@@ -790,6 +796,7 @@ export const Table = <TData,>({
                 className={styles.paginationPageSize}
                 options={PAGE_SIZE_OPTIONS}
                 value={{ value: pagination.value.pageSize }}
+                valueIcon="arrows-v"
                 onChange={(event) => {
                   pagination.onChange({
                     pageIndex: 0,

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableHeaderCell/TableHeaderCell.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableHeaderCell/TableHeaderCell.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+
 import { GrafanaTheme2 } from '@grafana/data';
 
 /**
@@ -6,6 +7,13 @@ import { GrafanaTheme2 } from '@grafana/data';
  */
 export const getStyles = (theme: GrafanaTheme2) => {
   return {
+    label: css`
+      display: inline-flex;
+      align-items: center;
+      gap: ${theme.spacing(0.5)};
+      min-width: max-content;
+      white-space: nowrap;
+    `,
     labelSortable: css`
       cursor: pointer;
       &:hover {
@@ -15,6 +23,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     actionHeader: css`
       margin: ${theme.spacing(0)};
       margin-left: ${theme.spacing(1)};
+      white-space: nowrap;
     `,
     actions: css`
       display: flex;

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableHeaderCell/TableHeaderCell.tsx
@@ -13,7 +13,11 @@ import {
   TablePreferenceColumn,
   UserPreferences,
 } from 'app/plugins/panel/volkovlabs-table-panel/types';
-import { prepareColumnConfigsForPreferences, prepareColumnsWithFilters, prepareColumnsWithSorting } from 'app/plugins/panel/volkovlabs-table-panel/utils';
+import {
+  prepareColumnConfigsForPreferences,
+  prepareColumnsWithFilters,
+  prepareColumnsWithSorting,
+} from 'app/plugins/panel/volkovlabs-table-panel/utils';
 
 import { getStyles } from './TableHeaderCell.styles';
 import { TableHeaderCellFilter } from './TableHeaderCellFilter';
@@ -290,7 +294,7 @@ export const TableHeaderCell = <TData,>({
             updateTablesPreferences(currentTableName, transformedColumns);
           }
         }}
-        className={cx({
+        className={cx(styles.label, {
           [styles.labelSortable]: header.column.getCanSort(),
         })}
         style={{

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.styles.ts
@@ -50,11 +50,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       background-color: inherit;
       color: inherit;
     `,
-    cellEditable: css`
-      &:hover {
-        box-shadow: ${theme.colors.primary.border} 0 0 2px;
-      }
-    `,
+    cellEditable: css``,
     cellExpandable: css`
       cursor: pointer;
       border-right: none !important;

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.tsx
@@ -5,7 +5,11 @@ import { Cell, CellContext, Column, Row } from '@tanstack/react-table';
 import { VirtualItem, Virtualizer } from '@tanstack/react-virtual';
 import React, { CSSProperties } from 'react';
 
-import { ACTIONS_COLUMN_ID, AGGREGATION_TYPES_WITH_DISPLAY_PROCESSOR, TEST_IDS } from 'app/plugins/panel/volkovlabs-table-panel/constants';
+import {
+  ACTIONS_COLUMN_ID,
+  AGGREGATION_TYPES_WITH_DISPLAY_PROCESSOR,
+  TEST_IDS,
+} from 'app/plugins/panel/volkovlabs-table-panel/constants';
 import { CellType, ColumnAlignment, RowHighlightConfig } from 'app/plugins/panel/volkovlabs-table-panel/types';
 
 import { TableCell, TableEditableCell } from './components';

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+
 import { GrafanaTheme2 } from '@grafana/data';
 
 /**
@@ -12,6 +13,9 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     menuWrapper: css({
       zIndex: theme.zIndex.dropdown,
+    }),
+    valueIcon: css({
+      color: theme.colors.text.disabled,
     }),
   };
 };

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.tsx
@@ -8,11 +8,11 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
-import { SelectableValue } from '@grafana/data';
-import { Menu, MenuItem, Portal, ToolbarButton, useTheme2 } from '@grafana/ui';
 import { FocusScope } from '@react-aria/focus';
 import React, { HTMLAttributes, useState } from 'react';
 
+import { SelectableValue } from '@grafana/data';
+import { Icon, Menu, MenuItem, Portal, ToolbarButton, useTheme2 } from '@grafana/ui';
 import { TEST_IDS } from 'app/plugins/panel/volkovlabs-table-panel/constants';
 
 import { getStyles } from './ButtonSelect.styles';
@@ -91,6 +91,7 @@ export const ButtonSelect = <T,>(props: Props<T>) => {
         {...restProps}
       >
         {value?.label || String(value?.value)}
+        <Icon name="arrows-v" size="sm" className={styles.valueIcon} />
       </ToolbarButton>
       {isOpen && (
         <Portal>

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/ui/ButtonSelect/ButtonSelect.tsx
@@ -11,7 +11,7 @@ import {
 import { FocusScope } from '@react-aria/focus';
 import React, { HTMLAttributes, useState } from 'react';
 
-import { SelectableValue } from '@grafana/data';
+import { IconName, SelectableValue } from '@grafana/data';
 import { Icon, Menu, MenuItem, Portal, ToolbarButton, useTheme2 } from '@grafana/ui';
 import { TEST_IDS } from 'app/plugins/panel/volkovlabs-table-panel/constants';
 
@@ -35,6 +35,7 @@ interface Props<T> extends HTMLAttributes<HTMLButtonElement> {
   narrow?: boolean;
   variant?: ToolbarButtonVariant;
   tooltip?: string;
+  valueIcon?: IconName;
 }
 
 export const ButtonSelect = <T,>(props: Props<T>) => {
@@ -44,7 +45,7 @@ export const ButtonSelect = <T,>(props: Props<T>) => {
   const theme = useTheme2();
   const styles = getStyles(theme);
 
-  const { className, options, value, onChange, narrow, variant, ...restProps } = props;
+  const { className, options, value, onChange, narrow, variant, valueIcon, ...restProps } = props;
   const [isOpen, setIsOpen] = useState(false);
 
   /**
@@ -83,15 +84,16 @@ export const ButtonSelect = <T,>(props: Props<T>) => {
     <div className={styles.wrapper} {...TEST_IDS.buttonSelect.root.apply()}>
       <ToolbarButton
         className={className}
-        isOpen={isOpen}
+        isOpen={valueIcon ? undefined : isOpen}
         narrow={narrow}
         variant={variant}
         ref={refs.setReference}
         {...getReferenceProps()}
+        aria-expanded={isOpen}
         {...restProps}
       >
         {value?.label || String(value?.value)}
-        <Icon name="arrows-v" size="sm" className={styles.valueIcon} />
+        {valueIcon && <Icon name={valueIcon} size="sm" className={styles.valueIcon} />}
       </ToolbarButton>
       {isOpen && (
         <Portal>

--- a/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
@@ -42,6 +42,15 @@ import { useNestedObjects } from './useNestedObjects';
 import { useRuntimeVariables } from './useRuntimeVariables';
 
 /**
+ * Estimate a minimum column width that can display the full header without clipping.
+ */
+const getHeaderMinWidth = (header: string, fontSize: ColumnHeaderFontSize): number => {
+  const characterWidth = fontSize === ColumnHeaderFontSize.LG ? 10 : fontSize === ColumnHeaderFontSize.XS ? 6 : 8;
+
+  return Math.ceil(header.length * characterWidth + 64);
+};
+
+/**
  * Use Table
  */
 export const useTable = ({
@@ -396,17 +405,22 @@ export const useTable = ({
         }
       }
 
+      const header = replaceVariables(column.config.label) || column.field.config?.displayName || column.field.name;
+      const headerMinWidth = getHeaderMinWidth(
+        header,
+        column.config.appearance.header.fontSize ?? ColumnHeaderFontSize.MD
+      );
       const sizeParams: Partial<Pick<ColumnDef<unknown>, 'size' | 'minSize' | 'maxSize'>> = {};
 
       /**
        * Set column size
        */
       if (column.config.appearance.width.auto) {
-        sizeParams.minSize = column.config.appearance.width.min;
-        sizeParams.maxSize = column.config.appearance.width.max;
+        sizeParams.minSize = Math.max(column.config.appearance.width.min, headerMinWidth);
+        sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth);
       } else {
-        sizeParams.size = column.config.appearance.width.value;
-        sizeParams.maxSize = column.config.appearance.width.value;
+        sizeParams.size = Math.max(column.config.appearance.width.value, headerMinWidth);
+        sizeParams.maxSize = Math.max(column.config.appearance.width.value, headerMinWidth);
       }
 
       const isEditAllowed = checkIfOperationEnabled(column.config.edit, {
@@ -427,8 +441,6 @@ export const useTable = ({
         column.config.type === CellType.NESTED_OBJECTS
           ? objects.find((object) => object.id === column.config.objectId)
           : undefined;
-
-      const header = replaceVariables(column.config.label) || column.field.config?.displayName || column.field.name;
 
       /**
        * Check for columns with grouping enabled that are last and may not have sub rows
@@ -508,6 +520,15 @@ export const useTable = ({
       }
 
       const header = actionsColumnConfig?.label ? replaceVariables(actionsColumnConfig?.label) : '';
+      const headerMinWidth = getHeaderMinWidth(header, actionsColumnConfig?.fontSize ?? ColumnHeaderFontSize.LG);
+
+      if (actionsColumnConfig?.width.auto) {
+        actionColumnSize.minSize = Math.max(actionColumnSize.minSize ?? 0, headerMinWidth);
+        actionColumnSize.maxSize = Math.max(actionColumnSize.maxSize ?? 0, headerMinWidth);
+      } else {
+        actionColumnSize.size = Math.max(actionColumnSize.size ?? 0, headerMinWidth);
+        actionColumnSize.maxSize = Math.max(actionColumnSize.maxSize ?? 0, headerMinWidth);
+      }
 
       const currentMeta = {
         config: {


### PR DESCRIPTION
## Summary
- Set TanStack Table pageCount for manual pagination so row virtualization uses the actual loaded page rows instead of the selected page size.
- Prevents extra blank scroll space when choosing a page size larger than the number of rows returned (for example, page size 1000 with 100 rows).

## Verification
- yarn eslint public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.tsx --ext .tsx --no-cache
- yarn build

## Notes
- Targeted Table.test.tsx could not run in this local checkout because @volkovlabs/jest-selectors is missing from installed dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pagination count for manual mode and ensured page count is at least 1.
  * Adjusted row virtualization to fully render small pages when appropriate.

* **UI**
  * Replaced shared pagination with compact prev/next navigation and current-page indicator; page-size selector retained.
  * Added an optional icon to the page-size selector display.
  * Prevented header labels from wrapping.

* **Style**
  * New themed pagination controls, hover/disabled states, and layout tweaks.

* **Tests**
  * Updated pagination tests to match new navigation UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->