### PR TITLE
Align table columns across rows by stabilising cell widths

### DIFF
--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts
@@ -62,7 +62,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       padding: ${theme.spacing(1, 2)} !important;
       gap: ${theme.spacing(0.5)};
       flex-wrap: nowrap;
-      flex: auto;
+      flex: 1 0 auto;
       overflow: visible;
       white-space: nowrap;
       color: ${theme.colors.text.secondary};
@@ -116,7 +116,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       padding: ${theme.spacing(1, 2)} !important;
       gap: ${theme.spacing(0.5)};
       flex-wrap: wrap;
-      flex: auto;
+      flex: 1 0 auto;
       color: ${theme.colors.text.secondary};
       background: ${theme.colors.background.primary};
     `,

--- a/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.styles.ts
+++ b/public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.styles.ts
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+
 import { GrafanaTheme2 } from '@grafana/data';
 
 /**
@@ -43,7 +44,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
       box-sizing: border-box;
       white-space: nowrap;
       padding: ${theme.spacing(1, 2)} !important;
-      flex: auto;
+      flex: 1 0 auto;
       overflow: hidden;
       text-overflow: ellipsis;
       z-index: 0;

--- a/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
@@ -414,10 +414,18 @@ export const useTable = ({
 
       /**
        * Set column size
+       *
+       * `width.min` and `width.max` are optional and may be undefined. Passing `undefined`
+       * to `Math.max` produces `NaN`, which would propagate through TanStack's `getSize()`
+       * and leave the cell without an inline width, allowing rows to size themselves to
+       * content and pushing columns out of alignment. Default the bound to `headerMinWidth`
+       * (and the fixed-size case to the configured value) before clamping.
        */
       if (column.config.appearance.width.auto) {
-        sizeParams.minSize = Math.max(column.config.appearance.width.min, headerMinWidth);
-        sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth);
+        sizeParams.minSize = Math.max(column.config.appearance.width.min ?? headerMinWidth, headerMinWidth);
+        if (column.config.appearance.width.max !== undefined) {
+          sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth);
+        }
       } else {
         sizeParams.size = Math.max(column.config.appearance.width.value, headerMinWidth);
         sizeParams.maxSize = Math.max(column.config.appearance.width.value, headerMinWidth);

--- a/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
+++ b/public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx
@@ -424,7 +424,13 @@ export const useTable = ({
       if (column.config.appearance.width.auto) {
         sizeParams.minSize = Math.max(column.config.appearance.width.min ?? headerMinWidth, headerMinWidth);
         if (column.config.appearance.width.max !== undefined) {
-          sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth);
+          /**
+           * Clamp `maxSize` to at least `minSize` so a misconfigured range
+           * (e.g. width.min > width.max) cannot produce maxSize < minSize,
+           * which would let TanStack's `getSize()` collapse the column below
+           * the header floor.
+           */
+          sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth, sizeParams.minSize);
         }
       } else {
         sizeParams.size = Math.max(column.config.appearance.width.value, headerMinWidth);


### PR DESCRIPTION
## Summary

Fixes a Volkov Labs table panel bug where columns expanded to fit the longest text in any row, leaving columns visibly misaligned between header and body (and between rows). The misalignment was most visible on the "Tool Findings" table on the CodeRabbit data‑metrics dashboard, where the table has only four columns and short configured min‑widths, so the bug had room to surface.

## Root cause

Two interacting issues, both rooted in PR #221:

1. **`NaN` widths from `Math.max(undefined, …)`** in `useTable.tsx`.

   ```ts
   sizeParams.minSize = Math.max(column.config.appearance.width.min, headerMinWidth);
   sizeParams.maxSize = Math.max(column.config.appearance.width.max, headerMinWidth);
   ```

   `appearance.width.min` and `appearance.width.max` are both optional. When they are not configured, `Math.max(undefined, X)` returns `NaN`. That `NaN` was assigned to TanStack's `minSize` / `maxSize` and flowed through `column.getSize()`:

   ```
   Math.min(Math.max(NaN, size ?? 150), NaN) === NaN
   ```

   React then dropped the `width` inline style on `<th>` / `<td>` entirely (only `min-width` remained). With no `width` set, the flex `basis` fell back to the cell's intrinsic content size — different per row — and rows ended up self‑sizing to content instead of matching the header.

   DOM inspection on the affected page confirmed it:

   | header `width` | row width | row content |
   | --- | --- | --- |
   | `""` (empty) | `207px` | `LanguageTool` |
   | `""` (empty) | `410px` | `QB_NEW_EN_ORTHOGRAPHY_ERROR_ID` |
   | `""` (empty) | `175px` | `grammar` |
   | `""` (empty) | `132px` | `21` |

   Other tables happened to look aligned only because their min‑widths were large enough to dominate the layout, masking the same underlying bug.

2. **`flex: auto` (= `1 1 auto`)** on header / body / footer cells. Even with a sane basis, `flex-shrink: 1` allowed cells to drift per row when one row's content was longer than another's. Switching to `flex: 1 0 auto` keeps cells growing into any leftover row space evenly (so the table still fills its width when min‑widths don't sum to the row) while preventing per‑row shrinkage.

## Changes

- `public/app/plugins/panel/volkovlabs-table-panel/hooks/useTable.tsx`
  - Default `width.min` to `headerMinWidth` before clamping, so `minSize` is always a real number.
  - Only set `maxSize` when `width.max` is explicitly configured (otherwise let TanStack use its default `Number.MAX_SAFE_INTEGER`).
  - Add a comment documenting the `NaN`‑propagation pitfall so it isn't re‑introduced.
- `public/app/plugins/panel/volkovlabs-table-panel/components/Table/Table.styles.ts`
  - `flex: auto` → `flex: 1 0 auto` on `headerCell` and `footerCell`.
- `public/app/plugins/panel/volkovlabs-table-panel/components/Table/components/TableRow/TableRow.styles.ts`
  - `flex: auto` → `flex: 1 0 auto` on body `cell`.

## Verification

- `yarn eslint <changed files> --no-cache` — passes for the two style files; the three `import/order` warnings on `useTable.tsx` are pre‑existing on the base branch and unrelated to this change.
- `npx tsc --noEmit` filtered to the changed files — no type errors.
- `yarn jest …/hooks/useTable.test.tsx --watchAll=false` — 27 pass / 5 fail, **identical to the baseline** (`git stash` confirmed). The 5 failures pre‑date this PR (they were introduced by PR #221's `headerMinWidth` floor and assert the un‑floored `minSize`); updating them belongs to a follow‑up.
- `Table.test.tsx` cannot run in the local checkout because `@volkovlabs/jest-selectors` is not installed — a known limitation noted in PR #221.
- Manual DOM inspection on the affected dashboard confirmed cells previously had empty inline `width`; with the fix in place all rows render the same column widths as the header.

## Notes

- The `import/order` reorder in `TableRow.styles.ts` is a `yarn eslint --fix` auto‑fix on the file already touched by this change; the actual fix is the single `flex` line.
- Behavior preserved for columns that explicitly configure `width.min` / `width.max` — the existing `Math.max(value, headerMinWidth)` logic is unchanged for those paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in column width calculations that could produce invalid sizes and break table layout when optional width bounds were not provided.

* **Style**
  * Adjusted table header, footer, and cell flex sizing from automatic to proportional behavior for more consistent spacing, alignment, and responsive distribution across columns and rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->