### PR TITLE
feat(mfe): redact raw datasource queries on both /api/ds/query (frontend) and GET /dashboards/uid/{uid} (backend) when running as CR MFE

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -21,7 +21,7 @@ export {
 } from './utils/DataSourceWithBackend';
 export {
   buildMfeContext,
-  hasRedactedRawSql,
+  hasRedactedQueryField,
   isFnDashboardWindow,
   type MfeContext,
 } from './utils/fnDashboardBody';

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -20,10 +20,10 @@ export {
   isExpressionReference,
 } from './utils/DataSourceWithBackend';
 export {
-  buildCrFnContext,
+  buildMfeContext,
   hasRedactedRawSql,
   isFnDashboardWindow,
-  type CrFnContext,
+  type MfeContext,
 } from './utils/fnDashboardBody';
 export {
   toDataQueryResponse,

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -20,6 +20,12 @@ export {
   isExpressionReference,
 } from './utils/DataSourceWithBackend';
 export {
+  buildCrFnContext,
+  hasRedactedRawSql,
+  isFnDashboardWindow,
+  type CrFnContext,
+} from './utils/fnDashboardBody';
+export {
   toDataQueryResponse,
   frameToMetricFindValue,
   type BackendDataSourceResponse,

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -47,6 +47,8 @@ const backendSrv = {
   },
 } as unknown as BackendSrv;
 
+const mockTemplateVariables: Array<{ name: string; current: { value: unknown } }> = [];
+
 jest.mock('../services', () => ({
   ...jest.requireActual('../services'),
   getBackendSrv: () => backendSrv,
@@ -58,6 +60,9 @@ jest.mock('../services', () => ({
       }),
     };
   },
+  getTemplateSrv: () => ({
+    getVariables: () => mockTemplateVariables,
+  }),
 }));
 jest.mock('./publicDashboardQueryHandler');
 
@@ -546,6 +551,39 @@ describe('DataSourceWithBackend', () => {
         from: '1697133600000',
         to: '1697155200000',
       });
+    });
+
+    test('merges dashboard-level template variables into the FN body', () => {
+      window.__FNDashboard__ = true;
+      mockTemplateVariables.length = 0;
+      mockTemplateVariables.push(
+        { name: 'org_id', current: { value: 'org-uuid' } },
+        { name: 'repo_name', current: { value: ['a', 'b'] } },
+      );
+
+      const { mock, ds } = createMockDatasource();
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        scopedVars: {
+          __interval: { text: '1m', value: '1m' },
+          // Panel-scoped vars must win over dashboard-level vars of the same name.
+          org_id: { text: 'panel-override', value: 'panel-override' },
+        },
+        range: getDefaultTimeRange(),
+      } as unknown as DataQueryRequest);
+
+      const body = mock.calls[0][0].data;
+      expect(body.variables).toEqual({
+        org_id: 'panel-override',
+        repo_name: ['a', 'b'],
+        __interval: '1m',
+      });
+
+      mockTemplateVariables.length = 0;
     });
   });
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -585,6 +585,38 @@ describe('DataSourceWithBackend', () => {
 
       mockTemplateVariables.length = 0;
     });
+
+    test('emits a variableQueries body when rawSql is [REDACTED] and panelId is missing', () => {
+      window.__FNDashboard__ = true;
+      window.__FNDashboardRenderingUID__ = 'dashB';
+      mockTemplateVariables.length = 0;
+      mockTemplateVariables.push({ name: 'org_id', current: { value: 'org-uuid' } });
+
+      const { mock, ds } = createMockDatasource();
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        // Note: no dashboardUID / panelId — this is how Grafana's variable
+        // runner dispatches templating-variable queries.
+        targets: [{ refId: 'org_name', rawSql: '[REDACTED]' }],
+        range: getDefaultTimeRange(),
+      } as unknown as DataQueryRequest);
+
+      const body = mock.calls[0][0].data;
+      expect(body).not.toHaveProperty('queries');
+      expect(body).not.toHaveProperty('panelId');
+      expect(body).toEqual({
+        dashboardUID: 'dashB',
+        variableQueries: [{ refId: 'org_name' }],
+        variables: { org_id: 'org-uuid' },
+        filters: [],
+        from: '1697133600000',
+        to: '1697155200000',
+      });
+
+      delete (window as { __FNDashboardRenderingUID__?: string }).__FNDashboardRenderingUID__;
+      mockTemplateVariables.length = 0;
+    });
   });
 
   describe('public dashboard scope', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -498,6 +498,57 @@ describe('DataSourceWithBackend', () => {
     });
   });
 
+  describe('FNDashboard (microfrontend) body rewriting', () => {
+    afterEach(() => {
+      delete (window as { __FNDashboard__?: boolean }).__FNDashboard__;
+    });
+
+    test('does not change the body when FNDashboard flag is not set', () => {
+      const { mock, ds } = createMockDatasource();
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        range: getDefaultTimeRange(),
+      } as DataQueryRequest);
+
+      const body = mock.calls[0][0].data;
+      expect(body).toHaveProperty('queries');
+      expect(body).not.toHaveProperty('dashboardUID');
+    });
+
+    test('rewrites the body to omit raw queries when FNDashboard flag is set', () => {
+      window.__FNDashboard__ = true;
+      const { mock, ds } = createMockDatasource();
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A' }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        scopedVars: {
+          host: { text: 'web-1', value: 'web-1' },
+          env: { text: 'prod', value: 'prod' },
+        },
+        filters: [{ key: 'team', operator: '=', value: 'sre' }],
+        range: getDefaultTimeRange(),
+      } as unknown as DataQueryRequest);
+
+      const body = mock.calls[0][0].data;
+      expect(body).not.toHaveProperty('queries');
+      expect(body).toEqual({
+        dashboardUID: 'dashA',
+        panelId: 123,
+        variables: { host: 'web-1', env: 'prod' },
+        filters: [{ key: 'team', operator: '=', value: 'sre' }],
+        from: '1697133600000',
+        to: '1697155200000',
+      });
+    });
+  });
+
   describe('public dashboard scope', () => {
     test("check public dashboard handler is not executed when it's not public dashboard scope", () => {
       const { ds } = createMockDatasource();

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -617,6 +617,29 @@ describe('DataSourceWithBackend', () => {
       delete (window as { __FNDashboardRenderingUID__?: string }).__FNDashboardRenderingUID__;
       mockTemplateVariables.length = 0;
     });
+
+    test('panel queries with redacted rawSql still emit a panel body (not variableQueries)', () => {
+      // Regression: after the backend mask redacts every panel target's
+      // rawSql to '[REDACTED]', `DataSourceWithBackend` previously routed
+      // those panel queries through the variable-query branch (because they
+      // had a redacted target). The proxy then looked refId=`A` up in the
+      // templating list, failed, and 400ed every panel. Discriminate on
+      // `panelId` instead.
+      window.__FNDashboard__ = true;
+      const { mock, ds } = createMockDatasource();
+      ds.query({
+        maxDataPoints: 10,
+        intervalMs: 5000,
+        targets: [{ refId: 'A', rawSql: '[REDACTED]' }],
+        dashboardUID: 'dashA',
+        panelId: 123,
+        range: getDefaultTimeRange(),
+      } as unknown as DataQueryRequest);
+
+      const body = mock.calls[0][0].data;
+      expect(body).toHaveProperty('panelId', 123);
+      expect(body).not.toHaveProperty('variableQueries');
+    });
   });
 
   describe('public dashboard scope', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -583,6 +583,35 @@ describe('DataSourceWithBackend', () => {
       expect(body.crFnContext.dashboardUID).toBe('dashB');
       expect(body.crFnContext.variables).toEqual({ org_id: 'org-uuid' });
     });
+
+    test('falls back to dashboard UID parsed from location.pathname', () => {
+      // Regression: in the Qiankun-sandboxed MFE, the
+      // `__FNDashboardRenderingUID__` window mirror may not be set yet when
+      // VariableQueryRunner fires its initial dropdown-population queries,
+      // and request.dashboardUID is also unset for those queries. The proxy
+      // then can't resolve the redacted SQL. Pull the UID out of the URL
+      // (which is always `/dashboard/<uid>` or `/d/<uid>/<slug>`) as a
+      // last-resort fallback.
+      window.__FNDashboard__ = true;
+      const originalPath = window.location.pathname;
+      const setPath = (p: string) =>
+        window.history.replaceState({}, '', p + window.location.search);
+      setPath('/dashboard/summary');
+      try {
+        const { mock, ds } = createMockDatasource();
+        ds.query({
+          maxDataPoints: 10,
+          intervalMs: 5000,
+          targets: [{ refId: 'A', rawSql: '[CR_REDACTED:v:org_name]' }],
+          range: getDefaultTimeRange(),
+        } as unknown as DataQueryRequest);
+
+        const body = mock.calls[0][0].data;
+        expect(body.crFnContext.dashboardUID).toBe('summary');
+      } finally {
+        setPath(originalPath);
+      }
+    });
   });
 
   describe('public dashboard scope', () => {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -506,6 +506,9 @@ describe('DataSourceWithBackend', () => {
   describe('FNDashboard (microfrontend) body rewriting', () => {
     afterEach(() => {
       delete (window as { __FNDashboard__?: boolean }).__FNDashboard__;
+      delete (window as { __FNDashboardRenderingUID__?: string })
+        .__FNDashboardRenderingUID__;
+      mockTemplateVariables.length = 0;
     });
 
     test('does not change the body when FNDashboard flag is not set', () => {
@@ -521,41 +524,11 @@ describe('DataSourceWithBackend', () => {
 
       const body = mock.calls[0][0].data;
       expect(body).toHaveProperty('queries');
-      expect(body).not.toHaveProperty('dashboardUID');
+      expect(body).not.toHaveProperty('crFnContext');
     });
 
-    test('rewrites the body to omit raw queries when FNDashboard flag is set', () => {
+    test('attaches crFnContext to the body when FNDashboard flag is set', () => {
       window.__FNDashboard__ = true;
-      const { mock, ds } = createMockDatasource();
-      ds.query({
-        maxDataPoints: 10,
-        intervalMs: 5000,
-        targets: [{ refId: 'A' }],
-        dashboardUID: 'dashA',
-        panelId: 123,
-        scopedVars: {
-          host: { text: 'web-1', value: 'web-1' },
-          env: { text: 'prod', value: 'prod' },
-        },
-        filters: [{ key: 'team', operator: '=', value: 'sre' }],
-        range: getDefaultTimeRange(),
-      } as unknown as DataQueryRequest);
-
-      const body = mock.calls[0][0].data;
-      expect(body).not.toHaveProperty('queries');
-      expect(body).toEqual({
-        dashboardUID: 'dashA',
-        panelId: 123,
-        variables: { host: 'web-1', env: 'prod' },
-        filters: [{ key: 'team', operator: '=', value: 'sre' }],
-        from: '1697133600000',
-        to: '1697155200000',
-      });
-    });
-
-    test('merges dashboard-level template variables into the FN body', () => {
-      window.__FNDashboard__ = true;
-      mockTemplateVariables.length = 0;
       mockTemplateVariables.push(
         { name: 'org_id', current: { value: 'org-uuid' } },
         { name: 'repo_name', current: { value: ['a', 'b'] } },
@@ -565,80 +538,50 @@ describe('DataSourceWithBackend', () => {
       ds.query({
         maxDataPoints: 10,
         intervalMs: 5000,
-        targets: [{ refId: 'A' }],
+        targets: [{ refId: 'A', rawSql: '[CR_REDACTED:p:123:A]' }],
         dashboardUID: 'dashA',
         panelId: 123,
         scopedVars: {
           __interval: { text: '1m', value: '1m' },
-          // Panel-scoped vars must win over dashboard-level vars of the same name.
-          org_id: { text: 'panel-override', value: 'panel-override' },
         },
+        filters: [{ key: 'team', operator: '=', value: 'sre' }],
         range: getDefaultTimeRange(),
       } as unknown as DataQueryRequest);
 
       const body = mock.calls[0][0].data;
-      expect(body.variables).toEqual({
-        org_id: 'panel-override',
-        repo_name: ['a', 'b'],
-        __interval: '1m',
+      // Body retains the legacy { queries, from, to } shape so unknown
+      // upstream code paths (including non-FN proxies) keep working.
+      expect(body).toHaveProperty('queries');
+      expect(body).toHaveProperty('crFnContext');
+      expect(body.crFnContext).toEqual({
+        variables: {
+          org_id: 'org-uuid',
+          repo_name: ['a', 'b'],
+          __interval: '1m',
+        },
+        filters: [{ key: 'team', operator: '=', value: 'sre' }],
+        dashboardUID: 'dashA',
       });
-
-      mockTemplateVariables.length = 0;
     });
 
-    test('emits a variableQueries body when rawSql is [REDACTED] and panelId is missing', () => {
+    test('falls back to window.__FNDashboardRenderingUID__ when request.dashboardUID is missing', () => {
       window.__FNDashboard__ = true;
       window.__FNDashboardRenderingUID__ = 'dashB';
-      mockTemplateVariables.length = 0;
       mockTemplateVariables.push({ name: 'org_id', current: { value: 'org-uuid' } });
 
       const { mock, ds } = createMockDatasource();
       ds.query({
         maxDataPoints: 10,
         intervalMs: 5000,
-        // Note: no dashboardUID / panelId — this is how Grafana's variable
-        // runner dispatches templating-variable queries.
-        targets: [{ refId: 'org_name', rawSql: '[REDACTED]' }],
+        // No dashboardUID / panelId — this is how Grafana's variable runner
+        // dispatches templating-variable queries.
+        targets: [{ refId: 'A', rawSql: '[CR_REDACTED:v:org_name]' }],
         range: getDefaultTimeRange(),
       } as unknown as DataQueryRequest);
 
       const body = mock.calls[0][0].data;
-      expect(body).not.toHaveProperty('queries');
-      expect(body).not.toHaveProperty('panelId');
-      expect(body).toEqual({
-        dashboardUID: 'dashB',
-        variableQueries: [{ refId: 'org_name' }],
-        variables: { org_id: 'org-uuid' },
-        filters: [],
-        from: '1697133600000',
-        to: '1697155200000',
-      });
-
-      delete (window as { __FNDashboardRenderingUID__?: string }).__FNDashboardRenderingUID__;
-      mockTemplateVariables.length = 0;
-    });
-
-    test('panel queries with redacted rawSql still emit a panel body (not variableQueries)', () => {
-      // Regression: after the backend mask redacts every panel target's
-      // rawSql to '[REDACTED]', `DataSourceWithBackend` previously routed
-      // those panel queries through the variable-query branch (because they
-      // had a redacted target). The proxy then looked refId=`A` up in the
-      // templating list, failed, and 400ed every panel. Discriminate on
-      // `panelId` instead.
-      window.__FNDashboard__ = true;
-      const { mock, ds } = createMockDatasource();
-      ds.query({
-        maxDataPoints: 10,
-        intervalMs: 5000,
-        targets: [{ refId: 'A', rawSql: '[REDACTED]' }],
-        dashboardUID: 'dashA',
-        panelId: 123,
-        range: getDefaultTimeRange(),
-      } as unknown as DataQueryRequest);
-
-      const body = mock.calls[0][0].data;
-      expect(body).toHaveProperty('panelId', 123);
-      expect(body).not.toHaveProperty('variableQueries');
+      expect(body.crFnContext.dashboardUID).toBe('dashB');
+      expect(body.crFnContext.variables).toEqual({ org_id: 'org-uuid' });
     });
   });
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts
@@ -524,10 +524,10 @@ describe('DataSourceWithBackend', () => {
 
       const body = mock.calls[0][0].data;
       expect(body).toHaveProperty('queries');
-      expect(body).not.toHaveProperty('crFnContext');
+      expect(body).not.toHaveProperty('mfeContext');
     });
 
-    test('attaches crFnContext to the body when FNDashboard flag is set', () => {
+    test('attaches mfeContext to the body when FNDashboard flag is set', () => {
       window.__FNDashboard__ = true;
       mockTemplateVariables.push(
         { name: 'org_id', current: { value: 'org-uuid' } },
@@ -538,7 +538,7 @@ describe('DataSourceWithBackend', () => {
       ds.query({
         maxDataPoints: 10,
         intervalMs: 5000,
-        targets: [{ refId: 'A', rawSql: '[CR_REDACTED:p:123:A]' }],
+        targets: [{ refId: 'A', rawSql: '[MFE_REDACTED:p:123:A]' }],
         dashboardUID: 'dashA',
         panelId: 123,
         scopedVars: {
@@ -552,8 +552,8 @@ describe('DataSourceWithBackend', () => {
       // Body retains the legacy { queries, from, to } shape so unknown
       // upstream code paths (including non-FN proxies) keep working.
       expect(body).toHaveProperty('queries');
-      expect(body).toHaveProperty('crFnContext');
-      expect(body.crFnContext).toEqual({
+      expect(body).toHaveProperty('mfeContext');
+      expect(body.mfeContext).toEqual({
         variables: {
           org_id: 'org-uuid',
           repo_name: ['a', 'b'],
@@ -575,13 +575,13 @@ describe('DataSourceWithBackend', () => {
         intervalMs: 5000,
         // No dashboardUID / panelId — this is how Grafana's variable runner
         // dispatches templating-variable queries.
-        targets: [{ refId: 'A', rawSql: '[CR_REDACTED:v:org_name]' }],
+        targets: [{ refId: 'A', rawSql: '[MFE_REDACTED:v:org_name]' }],
         range: getDefaultTimeRange(),
       } as unknown as DataQueryRequest);
 
       const body = mock.calls[0][0].data;
-      expect(body.crFnContext.dashboardUID).toBe('dashB');
-      expect(body.crFnContext.variables).toEqual({ org_id: 'org-uuid' });
+      expect(body.mfeContext.dashboardUID).toBe('dashB');
+      expect(body.mfeContext.variables).toEqual({ org_id: 'org-uuid' });
     });
 
     test('falls back to dashboard UID parsed from location.pathname', () => {
@@ -602,12 +602,12 @@ describe('DataSourceWithBackend', () => {
         ds.query({
           maxDataPoints: 10,
           intervalMs: 5000,
-          targets: [{ refId: 'A', rawSql: '[CR_REDACTED:v:org_name]' }],
+          targets: [{ refId: 'A', rawSql: '[MFE_REDACTED:v:org_name]' }],
           range: getDefaultTimeRange(),
         } as unknown as DataQueryRequest);
 
         const body = mock.calls[0][0].data;
-        expect(body.crFnContext.dashboardUID).toBe('summary');
+        expect(body.mfeContext.dashboardUID).toBe('summary');
       } finally {
         setPath(originalPath);
       }

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -188,11 +188,36 @@ class DataSourceWithBackend<
       return of({ data: [] });
     }
 
-    const body = {
+    let body: Record<string, unknown> = {
       queries,
       from: range?.from.valueOf().toString(),
       to: range?.to.valueOf().toString(),
     };
+
+    // When Grafana is running as a CodeRabbit microfrontend (FNDashboard), the
+    // raw query (e.g. SQL) must not be sent from the browser. The backend will
+    // resolve the query using the dashboard UID + panel id and apply any
+    // active variables / ad-hoc filters server-side instead.
+    if (typeof window !== 'undefined' && window.__FNDashboard__ === true) {
+      const variables = request.scopedVars
+        ? Object.keys(request.scopedVars).reduce<Record<string, unknown>>((acc, key) => {
+            const v = request.scopedVars[key];
+            if (v && typeof v === 'object' && 'value' in v) {
+              acc[key] = v.value;
+            }
+            return acc;
+          }, {})
+        : {};
+
+      body = {
+        dashboardUID: request.dashboardUID,
+        panelId: request.panelId,
+        variables,
+        filters: request.filters ?? [],
+        from: range?.from.valueOf().toString(),
+        to: range?.to.valueOf().toString(),
+      };
+    }
 
     if (config.featureToggles.queryOverLive) {
       return getGrafanaLiveSrv().getQueryData({

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -30,7 +30,7 @@ import {
   StreamingFrameOptions,
 } from '../services';
 
-import { buildCrFnContext, hasRedactedRawSql, isFnDashboardWindow } from './fnDashboardBody';
+import { buildMfeContext, hasRedactedRawSql, isFnDashboardWindow } from './fnDashboardBody';
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 
@@ -196,7 +196,7 @@ class DataSourceWithBackend<
     };
 
     // When the body carries a CodeRabbit redaction key OR the MFE store flag
-    // is set, attach the `crFnContext` sidecar that the proxy needs to
+    // is set, attach the `mfeContext` sidecar that the proxy needs to
     // resolve the redacted SQL. We accept both signals because variable
     // queries dispatched at dashboard-init time fire *before* the MFE store
     // mirror is set on `window.__FNDashboard__`.
@@ -204,7 +204,7 @@ class DataSourceWithBackend<
     if (isFnDashboardWindow() || hasRedactedRawSql(targetRawSqls)) {
       body = {
         ...body,
-        crFnContext: buildCrFnContext({
+        mfeContext: buildMfeContext({
           scopedVars: request.scopedVars,
           filters: request.filters,
           dashboardUIDFromRequest: request.dashboardUID,

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -26,11 +26,11 @@ import {
   getBackendSrv,
   getDataSourceSrv,
   getGrafanaLiveSrv,
-  getTemplateSrv,
   StreamingFrameAction,
   StreamingFrameOptions,
 } from '../services';
 
+import { buildCrFnContext, hasRedactedRawSql, isFnDashboardWindow } from './fnDashboardBody';
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 
@@ -195,50 +195,20 @@ class DataSourceWithBackend<
       to: range?.to.valueOf().toString(),
     };
 
-    // When Grafana is running as the CodeRabbit microfrontend (FNDashboard),
-    // the backend has masked every panel/templating-variable `rawSql` to a
-    // structural key (`[CR_REDACTED:p:<panelId>:<refId>]` /
-    // `[CR_REDACTED:v:<variableName>]`). Grafana's frontend forwards the
-    // masked SQL to /api/ds/query verbatim; the proxy decodes the key and
-    // looks up the original SQL server-side.
-    //
-    // For that resolution to apply variables / filters correctly the proxy
-    // needs the values selected in the UI — they live on `TemplateSrv` and
-    // in `request.scopedVars`, neither of which appear in the legacy body.
-    // Attach them as a sidecar `crFnContext` field on the body; the upstream
-    // Grafana datasource ignores unknown body fields, and the proxy uses it
-    // when it sees a redacted query.
-    if (typeof window !== 'undefined' && window.__FNDashboard__ === true) {
-      const variables: Record<string, unknown> = {};
-      try {
-        const templateSrv = getTemplateSrv();
-        if (templateSrv) {
-          for (const v of templateSrv.getVariables()) {
-            const value = (v as { current?: { value?: unknown } }).current?.value;
-            if (value !== undefined) {
-              variables[v.name] = value;
-            }
-          }
-        }
-      } catch {
-        // TemplateSrv may not be initialised in tests / non-dashboard contexts.
-      }
-      if (request.scopedVars) {
-        for (const key of Object.keys(request.scopedVars)) {
-          const v = request.scopedVars[key];
-          if (v && typeof v === 'object' && 'value' in v) {
-            variables[key] = v.value;
-          }
-        }
-      }
+    // When the body carries a CodeRabbit redaction key OR the MFE store flag
+    // is set, attach the `crFnContext` sidecar that the proxy needs to
+    // resolve the redacted SQL. We accept both signals because variable
+    // queries dispatched at dashboard-init time fire *before* the MFE store
+    // mirror is set on `window.__FNDashboard__`.
+    const targetRawSqls = queries.map(q => (q as unknown as { rawSql?: unknown }).rawSql as string | undefined);
+    if (isFnDashboardWindow() || hasRedactedRawSql(targetRawSqls)) {
       body = {
         ...body,
-        crFnContext: {
-          variables,
-          filters: request.filters ?? [],
-          dashboardUID:
-            request.dashboardUID ?? window.__FNDashboardRenderingUID__,
-        },
+        crFnContext: buildCrFnContext({
+          scopedVars: request.scopedVars,
+          filters: request.filters,
+          dashboardUIDFromRequest: request.dashboardUID,
+        }),
       };
     }
 

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -232,22 +232,21 @@ class DataSourceWithBackend<
         }
       }
 
-      // 3. Templating-variable queries (the dropdown population queries
-      //    fired by Grafana's variable runner) reach this branch without a
-      //    `dashboardUID` / `panelId`, and after our backend mask their
-      //    `rawSql` is the `[REDACTED]` placeholder — the proxy would reject
-      //    them. We detect this case by either a redacted target OR the
-      //    absence of a panelId combined with the presence of a refId that
-      //    matches a known templating variable name on the dashboard. The
-      //    dashboard UID is mirrored on `window` by the MFE store reducer
-      //    because `request.dashboardUID` is unset for variable queries.
-      const hasRedactedTarget = queries.some((q) => {
-        const raw = (q as unknown as { rawSql?: unknown }).rawSql;
-        return typeof raw === 'string' && raw === '[REDACTED]';
-      });
-      const dashboardUID = request.dashboardUID ?? window.__FNDashboardRenderingUID__;
+      // 3. Discriminate between *panel* queries (which always carry a
+      //    numeric `panelId` on the request — Grafana's `PanelQueryRunner`
+      //    sets it) and *templating-variable* queries (which Grafana's
+      //    `VariableQueryRunner` dispatches without a panelId). After our
+      //    backend mask, *both* shapes arrive with `rawSql === '[REDACTED]'`,
+      //    so the presence of a redacted target is NOT a reliable signal —
+      //    we must key off `panelId` instead, otherwise panel queries get
+      //    misrouted into the variable resolver (which looks up the target's
+      //    refId — `A` for panels — in the templating list, fails to find
+      //    it, and 400s).
+      const dashboardUID =
+        request.dashboardUID ?? window.__FNDashboardRenderingUID__;
+      const isVariableQuery = typeof request.panelId !== 'number';
 
-      if (hasRedactedTarget && dashboardUID) {
+      if (isVariableQuery && dashboardUID) {
         // Variable-query FN body: forward each target's refId as the variable
         // name. The proxy looks the SQL up in the shipped dashboard JSON,
         // interpolates variables, expands macros, and forwards the resolved

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -26,6 +26,7 @@ import {
   getBackendSrv,
   getDataSourceSrv,
   getGrafanaLiveSrv,
+  getTemplateSrv,
   StreamingFrameAction,
   StreamingFrameOptions,
 } from '../services';
@@ -199,15 +200,37 @@ class DataSourceWithBackend<
     // resolve the query using the dashboard UID + panel id and apply any
     // active variables / ad-hoc filters server-side instead.
     if (typeof window !== 'undefined' && window.__FNDashboard__ === true) {
-      const variables = request.scopedVars
-        ? Object.keys(request.scopedVars).reduce<Record<string, unknown>>((acc, key) => {
-            const v = request.scopedVars[key];
-            if (v && typeof v === 'object' && 'value' in v) {
-              acc[key] = v.value;
+      // 1. Dashboard-level template variables (org_id, repo_name, ...). These
+      //    live on the TemplateSrv, *not* in request.scopedVars (which only
+      //    carries panel-local vars like __interval / repeat). Without them
+      //    the proxy substitutes `\$org_id` with the dashboard's `allValue`
+      //    (often `''`), and every panel returns zero rows.
+      const variables: Record<string, unknown> = {};
+      try {
+        const templateSrv = getTemplateSrv();
+        if (templateSrv) {
+          for (const v of templateSrv.getVariables()) {
+            // Variable models carry the current selection under `current.value`.
+            const value = (v as { current?: { value?: unknown } }).current?.value;
+            if (value !== undefined) {
+              variables[v.name] = value;
             }
-            return acc;
-          }, {})
-        : {};
+          }
+        }
+      } catch {
+        // ignore — TemplateSrv may not be initialised in tests / non-dashboard contexts
+      }
+
+      // 2. Panel-scoped vars (e.g. __interval / __interval_ms / repeat vars)
+      //    override dashboard-level vars for this specific request.
+      if (request.scopedVars) {
+        for (const key of Object.keys(request.scopedVars)) {
+          const v = request.scopedVars[key];
+          if (v && typeof v === 'object' && 'value' in v) {
+            variables[key] = v.value;
+          }
+        }
+      }
 
       body = {
         dashboardUID: request.dashboardUID,

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -30,7 +30,7 @@ import {
   StreamingFrameOptions,
 } from '../services';
 
-import { buildMfeContext, hasRedactedRawSql, isFnDashboardWindow } from './fnDashboardBody';
+import { buildMfeContext, hasRedactedQueryField, isFnDashboardWindow } from './fnDashboardBody';
 import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
 import { BackendDataSourceResponse, toDataQueryResponse } from './queryResponse';
 
@@ -195,13 +195,13 @@ class DataSourceWithBackend<
       to: range?.to.valueOf().toString(),
     };
 
-    // When the body carries a CodeRabbit redaction key OR the MFE store flag
-    // is set, attach the `mfeContext` sidecar that the proxy needs to
-    // resolve the redacted SQL. We accept both signals because variable
-    // queries dispatched at dashboard-init time fire *before* the MFE store
-    // mirror is set on `window.__FNDashboard__`.
-    const targetRawSqls = queries.map(q => (q as unknown as { rawSql?: unknown }).rawSql as string | undefined);
-    if (isFnDashboardWindow() || hasRedactedRawSql(targetRawSqls)) {
+    // When the body carries a CodeRabbit redaction marker on any masked
+    // query field (rawSql / expr / query / rawQuery / queryText / target)
+    // OR the MFE store flag is set, attach the `mfeContext` sidecar that
+    // the proxy needs to resolve the redacted query. We accept both signals
+    // because variable queries dispatched at dashboard-init time fire
+    // *before* the MFE store mirror is set on `window.__FNDashboard__`.
+    if (isFnDashboardWindow() || hasRedactedQueryField(queries)) {
       body = {
         ...body,
         mfeContext: buildMfeContext({

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -232,14 +232,46 @@ class DataSourceWithBackend<
         }
       }
 
-      body = {
-        dashboardUID: request.dashboardUID,
-        panelId: request.panelId,
-        variables,
-        filters: request.filters ?? [],
-        from: range?.from.valueOf().toString(),
-        to: range?.to.valueOf().toString(),
-      };
+      // 3. Templating-variable queries (the dropdown population queries
+      //    fired by Grafana's variable runner) reach this branch without a
+      //    `dashboardUID` / `panelId`, and after our backend mask their
+      //    `rawSql` is the `[REDACTED]` placeholder — the proxy would reject
+      //    them. We detect this case by either a redacted target OR the
+      //    absence of a panelId combined with the presence of a refId that
+      //    matches a known templating variable name on the dashboard. The
+      //    dashboard UID is mirrored on `window` by the MFE store reducer
+      //    because `request.dashboardUID` is unset for variable queries.
+      const hasRedactedTarget = queries.some((q) => {
+        const raw = (q as unknown as { rawSql?: unknown }).rawSql;
+        return typeof raw === 'string' && raw === '[REDACTED]';
+      });
+      const dashboardUID = request.dashboardUID ?? window.__FNDashboardRenderingUID__;
+
+      if (hasRedactedTarget && dashboardUID) {
+        // Variable-query FN body: forward each target's refId as the variable
+        // name. The proxy looks the SQL up in the shipped dashboard JSON,
+        // interpolates variables, expands macros, and forwards the resolved
+        // queries[] to upstream Grafana.
+        body = {
+          dashboardUID,
+          variableQueries: queries.map((q) => ({
+            refId: (q as { refId?: string }).refId ?? 'A',
+          })),
+          variables,
+          filters: request.filters ?? [],
+          from: range?.from.valueOf().toString(),
+          to: range?.to.valueOf().toString(),
+        };
+      } else {
+        body = {
+          dashboardUID,
+          panelId: request.panelId,
+          variables,
+          filters: request.filters ?? [],
+          from: range?.from.valueOf().toString(),
+          to: range?.to.valueOf().toString(),
+        };
+      }
     }
 
     if (config.featureToggles.queryOverLive) {

--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -195,22 +195,25 @@ class DataSourceWithBackend<
       to: range?.to.valueOf().toString(),
     };
 
-    // When Grafana is running as a CodeRabbit microfrontend (FNDashboard), the
-    // raw query (e.g. SQL) must not be sent from the browser. The backend will
-    // resolve the query using the dashboard UID + panel id and apply any
-    // active variables / ad-hoc filters server-side instead.
+    // When Grafana is running as the CodeRabbit microfrontend (FNDashboard),
+    // the backend has masked every panel/templating-variable `rawSql` to a
+    // structural key (`[CR_REDACTED:p:<panelId>:<refId>]` /
+    // `[CR_REDACTED:v:<variableName>]`). Grafana's frontend forwards the
+    // masked SQL to /api/ds/query verbatim; the proxy decodes the key and
+    // looks up the original SQL server-side.
+    //
+    // For that resolution to apply variables / filters correctly the proxy
+    // needs the values selected in the UI — they live on `TemplateSrv` and
+    // in `request.scopedVars`, neither of which appear in the legacy body.
+    // Attach them as a sidecar `crFnContext` field on the body; the upstream
+    // Grafana datasource ignores unknown body fields, and the proxy uses it
+    // when it sees a redacted query.
     if (typeof window !== 'undefined' && window.__FNDashboard__ === true) {
-      // 1. Dashboard-level template variables (org_id, repo_name, ...). These
-      //    live on the TemplateSrv, *not* in request.scopedVars (which only
-      //    carries panel-local vars like __interval / repeat). Without them
-      //    the proxy substitutes `\$org_id` with the dashboard's `allValue`
-      //    (often `''`), and every panel returns zero rows.
       const variables: Record<string, unknown> = {};
       try {
         const templateSrv = getTemplateSrv();
         if (templateSrv) {
           for (const v of templateSrv.getVariables()) {
-            // Variable models carry the current selection under `current.value`.
             const value = (v as { current?: { value?: unknown } }).current?.value;
             if (value !== undefined) {
               variables[v.name] = value;
@@ -218,11 +221,8 @@ class DataSourceWithBackend<
           }
         }
       } catch {
-        // ignore — TemplateSrv may not be initialised in tests / non-dashboard contexts
+        // TemplateSrv may not be initialised in tests / non-dashboard contexts.
       }
-
-      // 2. Panel-scoped vars (e.g. __interval / __interval_ms / repeat vars)
-      //    override dashboard-level vars for this specific request.
       if (request.scopedVars) {
         for (const key of Object.keys(request.scopedVars)) {
           const v = request.scopedVars[key];
@@ -231,46 +231,15 @@ class DataSourceWithBackend<
           }
         }
       }
-
-      // 3. Discriminate between *panel* queries (which always carry a
-      //    numeric `panelId` on the request — Grafana's `PanelQueryRunner`
-      //    sets it) and *templating-variable* queries (which Grafana's
-      //    `VariableQueryRunner` dispatches without a panelId). After our
-      //    backend mask, *both* shapes arrive with `rawSql === '[REDACTED]'`,
-      //    so the presence of a redacted target is NOT a reliable signal —
-      //    we must key off `panelId` instead, otherwise panel queries get
-      //    misrouted into the variable resolver (which looks up the target's
-      //    refId — `A` for panels — in the templating list, fails to find
-      //    it, and 400s).
-      const dashboardUID =
-        request.dashboardUID ?? window.__FNDashboardRenderingUID__;
-      const isVariableQuery = typeof request.panelId !== 'number';
-
-      if (isVariableQuery && dashboardUID) {
-        // Variable-query FN body: forward each target's refId as the variable
-        // name. The proxy looks the SQL up in the shipped dashboard JSON,
-        // interpolates variables, expands macros, and forwards the resolved
-        // queries[] to upstream Grafana.
-        body = {
-          dashboardUID,
-          variableQueries: queries.map((q) => ({
-            refId: (q as { refId?: string }).refId ?? 'A',
-          })),
+      body = {
+        ...body,
+        crFnContext: {
           variables,
           filters: request.filters ?? [],
-          from: range?.from.valueOf().toString(),
-          to: range?.to.valueOf().toString(),
-        };
-      } else {
-        body = {
-          dashboardUID,
-          panelId: request.panelId,
-          variables,
-          filters: request.filters ?? [],
-          from: range?.from.valueOf().toString(),
-          to: range?.to.valueOf().toString(),
-        };
-      }
+          dashboardUID:
+            request.dashboardUID ?? window.__FNDashboardRenderingUID__,
+        },
+      };
     }
 
     if (config.featureToggles.queryOverLive) {

--- a/packages/grafana-runtime/src/utils/fnDashboardBody.test.ts
+++ b/packages/grafana-runtime/src/utils/fnDashboardBody.test.ts
@@ -1,0 +1,67 @@
+import { hasRedactedQueryField } from './fnDashboardBody';
+
+describe('hasRedactedQueryField', () => {
+  it('detects redaction on rawSql (SQL datasources)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', rawSql: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('detects redaction on expr (prometheus / loki)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', expr: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('detects redaction on query (elasticsearch / influxdb / cloudwatch)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', query: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('detects redaction on rawQuery (azure monitor / influxdb string variants)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', rawQuery: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('detects redaction on queryText (bigquery / snowflake / athena)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', queryText: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('detects redaction on target (graphite)', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', target: '[MFE_REDACTED:p:1:A]' }])).toBe(true);
+  });
+
+  it('returns true if any query in the array has a redacted field', () => {
+    expect(
+      hasRedactedQueryField([
+        { refId: 'A', rawSql: 'SELECT 1' },
+        { refId: 'B', expr: '[MFE_REDACTED:p:1:B]' },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when nothing is redacted', () => {
+    expect(
+      hasRedactedQueryField([
+        { refId: 'A', rawSql: 'SELECT 1' },
+        { refId: 'B', expr: 'up' },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false for an empty array', () => {
+    expect(hasRedactedQueryField([])).toBe(false);
+  });
+
+  it('ignores non-object entries (null / primitive)', () => {
+    expect(hasRedactedQueryField([null, undefined, 42, 'string'])).toBe(false);
+  });
+
+  it('ignores non-string masked-field values', () => {
+    expect(
+      hasRedactedQueryField([
+        { refId: 'A', rawSql: 123 },
+        { refId: 'B', rawQuery: true }, // azure-monitor toggle key — non-string is fine
+      ])
+    ).toBe(false);
+  });
+
+  it('only matches the literal redaction prefix', () => {
+    expect(hasRedactedQueryField([{ refId: 'A', rawSql: 'not [MFE_REDACTED:p:1:A]' }])).toBe(false);
+  });
+});
+

--- a/packages/grafana-runtime/src/utils/fnDashboardBody.ts
+++ b/packages/grafana-runtime/src/utils/fnDashboardBody.ts
@@ -3,10 +3,10 @@ import { AdHocVariableFilter, ScopedVars } from '@grafana/data';
 import { getTemplateSrv } from '../services';
 
 /**
- * Build the `crFnContext` sidecar that the CodeRabbit proxy uses to resolve
+ * Build the `mfeContext` sidecar that the CodeRabbit proxy uses to resolve
  * a redacted `/api/ds/query` body — i.e. one whose `rawSql` values are
- * `[CR_REDACTED:p:<panelId>:<refId>]` (panel target) or
- * `[CR_REDACTED:v:<variableName>]` (templating-variable query).
+ * `[MFE_REDACTED:p:<panelId>:<refId>]` (panel target) or
+ * `[MFE_REDACTED:v:<variableName>]` (templating-variable query).
  *
  * The proxy decodes each key, looks the original SQL up in its shipped
  * dashboard JSON, then interpolates the dashboard-level templating
@@ -24,17 +24,17 @@ import { getTemplateSrv } from '../services';
  *      inside Qiankun's `about:blank` sandbox iframe (whose own
  *      `location.pathname` is `"blank"`).
  */
-export interface CrFnContext {
+export interface MfeContext {
   variables: Record<string, unknown>;
   filters: AdHocVariableFilter[];
   dashboardUID?: string;
 }
 
-export function buildCrFnContext(opts: {
+export function buildMfeContext(opts: {
   scopedVars?: ScopedVars;
   filters?: AdHocVariableFilter[];
   dashboardUIDFromRequest?: string;
-}): CrFnContext {
+}): MfeContext {
   const variables: Record<string, unknown> = {};
 
   // 1. Dashboard-level template variables (org_id, repo_name, ...) live on
@@ -98,18 +98,18 @@ function resolveDashboardUID(fromRequest?: string): string | undefined {
 
 /**
  * Returns true if any of the supplied raw query texts is a CodeRabbit
- * redaction key (`[CR_REDACTED:...]`). Used to gate the attachment of the
- * `crFnContext` sidecar on bodies that the CR proxy will need to resolve.
+ * redaction key (`[MFE_REDACTED:...]`). Used to gate the attachment of the
+ * `mfeContext` sidecar on bodies that the MFE proxy will need to resolve.
  */
 export function hasRedactedRawSql(rawSqls: Array<string | undefined>): boolean {
-  return rawSqls.some(s => typeof s === 'string' && s.startsWith('[CR_REDACTED:'));
+  return rawSqls.some(s => typeof s === 'string' && s.startsWith('[MFE_REDACTED:'));
 }
 
 /**
  * True when the current window is the CodeRabbit microfrontend. The MFE
  * store mirrors this onto `window.__FNDashboard__` at dispatch time.
  * Initial templating-variable queries can fire *before* that mirror is
- * set, so callers that want to attach a `crFnContext` to any body that
+ * set, so callers that want to attach a `mfeContext` to any body that
  * already carries a redacted SQL should additionally check
  * {@link hasRedactedRawSql} on the request's targets.
  */

--- a/packages/grafana-runtime/src/utils/fnDashboardBody.ts
+++ b/packages/grafana-runtime/src/utils/fnDashboardBody.ts
@@ -1,0 +1,118 @@
+import { AdHocVariableFilter, ScopedVars } from '@grafana/data';
+
+import { getTemplateSrv } from '../services';
+
+/**
+ * Build the `crFnContext` sidecar that the CodeRabbit proxy uses to resolve
+ * a redacted `/api/ds/query` body — i.e. one whose `rawSql` values are
+ * `[CR_REDACTED:p:<panelId>:<refId>]` (panel target) or
+ * `[CR_REDACTED:v:<variableName>]` (templating-variable query).
+ *
+ * The proxy decodes each key, looks the original SQL up in its shipped
+ * dashboard JSON, then interpolates the dashboard-level templating
+ * variables and any panel-scoped overrides we forward here. Grafana's
+ * upstream datasource ignores unknown body fields, so the same body can be
+ * forwarded verbatim after resolution.
+ *
+ * `dashboardUID` is read from (in order):
+ *
+ *   1. `dashboardUIDFromRequest` if the caller supplies it (panel queries
+ *      have it on `DataQueryRequest.dashboardUID`).
+ *   2. The MFE store mirror `window.__FNDashboardRenderingUID__`.
+ *   3. The URL pathname (`/dashboard/<uid>` or `/d/<uid>/<slug>`),
+ *      walking up to `window.parent` / `window.top` when the MFE runs
+ *      inside Qiankun's `about:blank` sandbox iframe (whose own
+ *      `location.pathname` is `"blank"`).
+ */
+export interface CrFnContext {
+  variables: Record<string, unknown>;
+  filters: AdHocVariableFilter[];
+  dashboardUID?: string;
+}
+
+export function buildCrFnContext(opts: {
+  scopedVars?: ScopedVars;
+  filters?: AdHocVariableFilter[];
+  dashboardUIDFromRequest?: string;
+}): CrFnContext {
+  const variables: Record<string, unknown> = {};
+
+  // 1. Dashboard-level template variables (org_id, repo_name, ...) live on
+  //    TemplateSrv, *not* in scopedVars (which only carries panel-local vars
+  //    like `__interval` / repeat).
+  try {
+    const templateSrv = getTemplateSrv();
+    if (templateSrv) {
+      for (const v of templateSrv.getVariables()) {
+        const value = (v as { current?: { value?: unknown } }).current?.value;
+        if (value !== undefined) {
+          variables[v.name] = value;
+        }
+      }
+    }
+  } catch {
+    // TemplateSrv may not be initialised in tests / non-dashboard contexts.
+  }
+
+  // 2. Panel-scoped vars override dashboard-level vars of the same name.
+  if (opts.scopedVars) {
+    for (const key of Object.keys(opts.scopedVars)) {
+      const v = opts.scopedVars[key];
+      if (v && typeof v === 'object' && 'value' in v) {
+        variables[key] = (v as { value: unknown }).value;
+      }
+    }
+  }
+
+  return {
+    variables,
+    filters: opts.filters ?? [],
+    dashboardUID: resolveDashboardUID(opts.dashboardUIDFromRequest),
+  };
+}
+
+function resolveDashboardUID(fromRequest?: string): string | undefined {
+  if (fromRequest) return fromRequest;
+  if (typeof window === 'undefined') return undefined;
+  const fromWindow = window.__FNDashboardRenderingUID__;
+  if (fromWindow) return fromWindow;
+
+  const re = /^\/(?:dashboard|d)\/([^/?#]+)/;
+  const candidates: string[] = [window.location.pathname];
+  try {
+    if (window.parent && window.parent !== window) {
+      candidates.push(window.parent.location.pathname);
+    }
+    if (window.top && window.top !== window) {
+      candidates.push(window.top.location.pathname);
+    }
+  } catch {
+    // cross-origin parent — ignore
+  }
+  for (const c of candidates) {
+    const m = re.exec(c);
+    if (m && m[1]) return m[1];
+  }
+  return undefined;
+}
+
+/**
+ * Returns true if any of the supplied raw query texts is a CodeRabbit
+ * redaction key (`[CR_REDACTED:...]`). Used to gate the attachment of the
+ * `crFnContext` sidecar on bodies that the CR proxy will need to resolve.
+ */
+export function hasRedactedRawSql(rawSqls: Array<string | undefined>): boolean {
+  return rawSqls.some(s => typeof s === 'string' && s.startsWith('[CR_REDACTED:'));
+}
+
+/**
+ * True when the current window is the CodeRabbit microfrontend. The MFE
+ * store mirrors this onto `window.__FNDashboard__` at dispatch time.
+ * Initial templating-variable queries can fire *before* that mirror is
+ * set, so callers that want to attach a `crFnContext` to any body that
+ * already carries a redacted SQL should additionally check
+ * {@link hasRedactedRawSql} on the request's targets.
+ */
+export function isFnDashboardWindow(): boolean {
+  return typeof window !== 'undefined' && window.__FNDashboard__ === true;
+}

--- a/packages/grafana-runtime/src/utils/fnDashboardBody.ts
+++ b/packages/grafana-runtime/src/utils/fnDashboardBody.ts
@@ -97,12 +97,37 @@ function resolveDashboardUID(fromRequest?: string): string | undefined {
 }
 
 /**
- * Returns true if any of the supplied raw query texts is a CodeRabbit
- * redaction key (`[MFE_REDACTED:...]`). Used to gate the attachment of the
- * `mfeContext` sidecar on bodies that the MFE proxy will need to resolve.
+ * Fields the backend redacts when running as the CodeRabbit MFE
+ * (see `pkg/api/dashboard_mfe_mask.go::mfeMaskedQueryFields`). Any one of
+ * these on a query target may carry the `[MFE_REDACTED:...]` marker that
+ * the MFE proxy needs to resolve, so they must all be inspected here.
  */
-export function hasRedactedRawSql(rawSqls: Array<string | undefined>): boolean {
-  return rawSqls.some(s => typeof s === 'string' && s.startsWith('[MFE_REDACTED:'));
+const MFE_REDACTED_QUERY_FIELDS = [
+  'rawSql', // postgres, mysql, mssql
+  'expr', // prometheus, loki
+  'query', // elasticsearch, influxdb, cloudwatch, generic
+  'rawQuery', // azure monitor, influxdb (string-valued only)
+  'queryText', // bigquery, snowflake, athena
+  'target', // graphite
+] as const;
+
+const MFE_REDACTION_PREFIX = '[MFE_REDACTED:';
+
+/**
+ * Returns true if any of the supplied queries carries a CodeRabbit redaction
+ * marker (`[MFE_REDACTED:...]`) on any of the datasource-specific query-text
+ * fields the backend masks. Used to gate the attachment of the `mfeContext`
+ * sidecar on bodies that the MFE proxy will need to resolve — including
+ * non-SQL datasources whose raw text lives on `expr`, `query`, etc.
+ */
+export function hasRedactedQueryField(queries: ReadonlyArray<unknown>): boolean {
+  return queries.some((q) => {
+    if (typeof q !== 'object' || q === null) return false;
+    return MFE_REDACTED_QUERY_FIELDS.some((field) => {
+      const value = Reflect.get(q, field);
+      return typeof value === 'string' && value.startsWith(MFE_REDACTION_PREFIX);
+    });
+  });
 }
 
 /**
@@ -110,8 +135,8 @@ export function hasRedactedRawSql(rawSqls: Array<string | undefined>): boolean {
  * store mirrors this onto `window.__FNDashboard__` at dispatch time.
  * Initial templating-variable queries can fire *before* that mirror is
  * set, so callers that want to attach a `mfeContext` to any body that
- * already carries a redacted SQL should additionally check
- * {@link hasRedactedRawSql} on the request's targets.
+ * already carries a redacted query field should additionally check
+ * {@link hasRedactedQueryField} on the request's targets.
  */
 export function isFnDashboardWindow(): boolean {
   return typeof window !== 'undefined' && window.__FNDashboard__ === true;

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -215,7 +215,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     // is fixed.
     let response;
     try {
-      response = await this.runMetaQuery(interpolatedQuery, range);
+      response = await this.runMetaQuery(interpolatedQuery, range, scopedVars);
     } catch (error) {
       console.error(error);
       throw new Error('error when executing the sql query');
@@ -230,14 +230,21 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     return new DataFrameView<T>(frame);
   }
 
-  private runMetaQuery(request: Partial<SQLQuery>, range: TimeRange): Promise<DataFrame> {
+  private runMetaQuery(
+    request: Partial<SQLQuery>,
+    range: TimeRange,
+    scopedVars?: ScopedVars
+  ): Promise<DataFrame> {
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
     // Variable queries (and other metricFindQuery callers) bypass
     // `DataSourceWithBackend.query`, so we must attach the CodeRabbit MFE
     // `crFnContext` sidecar here too. The proxy needs it whenever a query's
-    // rawSql is a redaction key (e.g. `[CR_REDACTED:v:org_name]`).
+    // rawSql is a redaction key (e.g. `[CR_REDACTED:v:org_name]`). Forward
+    // the caller's scopedVars (which `metricFindQuery` populates with
+    // `options.scopedVars` + `__searchFilter`) so the proxy can interpolate
+    // them when it expands the redacted SQL.
     const rawSqls = queries.map(q => (q as unknown as { rawSql?: unknown }).rawSql as string | undefined);
     const data: Record<string, unknown> = {
       from: range.from.valueOf().toString(),
@@ -245,7 +252,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       queries,
     };
     if (isFnDashboardWindow() || hasRedactedRawSql(rawSqls)) {
-      data.crFnContext = buildCrFnContext({});
+      data.crFnContext = buildCrFnContext({ scopedVars });
     }
 
     return lastValueFrom(

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -22,8 +22,11 @@ import {
   BackendDataSourceResponse,
   DataSourceWithBackend,
   FetchResponse,
+  buildCrFnContext,
   getBackendSrv,
   getTemplateSrv,
+  hasRedactedRawSql,
+  isFnDashboardWindow,
   toDataQueryResponse,
   TemplateSrv,
   reportInteraction,
@@ -231,17 +234,27 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
+    // Variable queries (and other metricFindQuery callers) bypass
+    // `DataSourceWithBackend.query`, so we must attach the CodeRabbit MFE
+    // `crFnContext` sidecar here too. The proxy needs it whenever a query's
+    // rawSql is a redaction key (e.g. `[CR_REDACTED:v:org_name]`).
+    const rawSqls = queries.map(q => (q as unknown as { rawSql?: unknown }).rawSql as string | undefined);
+    const data: Record<string, unknown> = {
+      from: range.from.valueOf().toString(),
+      to: range.to.valueOf().toString(),
+      queries,
+    };
+    if (isFnDashboardWindow() || hasRedactedRawSql(rawSqls)) {
+      data.crFnContext = buildCrFnContext({});
+    }
+
     return lastValueFrom(
       getBackendSrv()
         .fetch<BackendDataSourceResponse>({
           url: '/api/ds/query',
           method: 'POST',
           headers: this.getRequestHeaders(),
-          data: {
-            from: range.from.valueOf().toString(),
-            to: range.to.valueOf().toString(),
-            queries,
-          },
+          data,
           requestId: refId,
         })
         .pipe(

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -22,7 +22,7 @@ import {
   BackendDataSourceResponse,
   DataSourceWithBackend,
   FetchResponse,
-  buildCrFnContext,
+  buildMfeContext,
   getBackendSrv,
   getTemplateSrv,
   hasRedactedRawSql,
@@ -239,9 +239,9 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
     // Variable queries (and other metricFindQuery callers) bypass
-    // `DataSourceWithBackend.query`, so we must attach the CodeRabbit MFE
-    // `crFnContext` sidecar here too. The proxy needs it whenever a query's
-    // rawSql is a redaction key (e.g. `[CR_REDACTED:v:org_name]`). Forward
+    // `DataSourceWithBackend.query`, so we must attach the MFE
+    // `mfeContext` sidecar here too. The proxy needs it whenever a query's
+    // rawSql is a redaction key (e.g. `[MFE_REDACTED:v:org_name]`). Forward
     // the caller's scopedVars (which `metricFindQuery` populates with
     // `options.scopedVars` + `__searchFilter`) so the proxy can interpolate
     // them when it expands the redacted SQL.
@@ -252,7 +252,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
       queries,
     };
     if (isFnDashboardWindow() || hasRedactedRawSql(rawSqls)) {
-      data.crFnContext = buildCrFnContext({ scopedVars });
+      data.mfeContext = buildMfeContext({ scopedVars });
     }
 
     return lastValueFrom(

--- a/packages/grafana-sql/src/datasource/SqlDatasource.ts
+++ b/packages/grafana-sql/src/datasource/SqlDatasource.ts
@@ -25,7 +25,7 @@ import {
   buildMfeContext,
   getBackendSrv,
   getTemplateSrv,
-  hasRedactedRawSql,
+  hasRedactedQueryField,
   isFnDashboardWindow,
   toDataQueryResponse,
   TemplateSrv,
@@ -230,28 +230,24 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
     return new DataFrameView<T>(frame);
   }
 
-  private runMetaQuery(
-    request: Partial<SQLQuery>,
-    range: TimeRange,
-    scopedVars?: ScopedVars
-  ): Promise<DataFrame> {
+  private runMetaQuery(request: Partial<SQLQuery>, range: TimeRange, scopedVars?: ScopedVars): Promise<DataFrame> {
     const refId = request.refId || 'meta';
     const queries: DataQuery[] = [{ ...request, datasource: request.datasource || this.getRef(), refId }];
 
     // Variable queries (and other metricFindQuery callers) bypass
     // `DataSourceWithBackend.query`, so we must attach the MFE
-    // `mfeContext` sidecar here too. The proxy needs it whenever a query's
-    // rawSql is a redaction key (e.g. `[MFE_REDACTED:v:org_name]`). Forward
-    // the caller's scopedVars (which `metricFindQuery` populates with
+    // `mfeContext` sidecar here too. The proxy needs it whenever a query
+    // carries a redaction marker on any masked query field (e.g.
+    // `[MFE_REDACTED:v:org_name]` on rawSql). Forward the caller's
+    // scopedVars (which `metricFindQuery` populates with
     // `options.scopedVars` + `__searchFilter`) so the proxy can interpolate
-    // them when it expands the redacted SQL.
-    const rawSqls = queries.map(q => (q as unknown as { rawSql?: unknown }).rawSql as string | undefined);
+    // them when it expands the redacted query.
     const data: Record<string, unknown> = {
       from: range.from.valueOf().toString(),
       to: range.to.valueOf().toString(),
       queries,
     };
-    if (isFnDashboardWindow() || hasRedactedRawSql(rawSqls)) {
+    if (isFnDashboardWindow() || hasRedactedQueryField(queries)) {
       data.mfeContext = buildMfeContext({ scopedVars });
     }
 

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -220,6 +220,13 @@ func (hs *HTTPServer) GetDashboard(c *contextmodel.ReqContext) response.Response
 	// make sure db version is in sync with json model version
 	dash.Data.Set("version", dash.Version)
 
+	// When Grafana is embedded as the CodeRabbit microfrontend, redact raw
+	// datasource queries (SQL, PromQL, ...) from the dashboard JSON so that
+	// they are never exposed to the browser.
+	if isCodeRabbitMFE() {
+		maskDashboardQueriesForMFE(dash.Data)
+	}
+
 	dto := dtos.DashboardFullWithMeta{
 		Dashboard: dash.Data,
 		Meta:      meta,

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -12,10 +13,6 @@ import (
 // flag is on, dashboard JSON responses must not expose raw datasource queries
 // (e.g. SQL) to the browser — the backend resolves them at query time instead.
 const crMFEEnvVar = "GF_CR_MFE"
-
-// crMaskedValue is the placeholder substituted in place of any raw query text
-// when running as the CodeRabbit microfrontend.
-const crMaskedValue = "[REDACTED]"
 
 // crMaskedQueryFields lists the JSON keys that carry raw, datasource-specific
 // query text on a panel target. We mask these explicitly (rather than
@@ -28,6 +25,37 @@ var crMaskedQueryFields = []string{
 	"rawQuery",  // azure monitor, influxdb (toggle key elsewhere — we mask string values only)
 	"queryText", // bigquery, snowflake, athena
 	"target",    // graphite
+}
+
+// Redacted value prefix and tag format. The frontend forwards the masked
+// rawSql verbatim to `/api/ds/query`; the CodeRabbit proxy recognises the
+// `[CR_REDACTED:...]` shape, decodes the key, looks the original SQL up in
+// its own indexed dashboard JSON copy, substitutes variables + macros and
+// forwards a resolved query upstream. The structure carries everything
+// needed for the lookup so we don't have to introduce an alternate body
+// shape on the frontend.
+//
+// Encoding (URL-safe — colons are the only delimiter):
+//
+//	panel target:        [CR_REDACTED:p:<panelId>:<refId>]
+//	templating variable: [CR_REDACTED:v:<variableName>]
+//
+// `<refId>` and `<variableName>` are pulled directly from the dashboard
+// JSON. Their character set in shipped dashboards is `[A-Za-z0-9_-]`; if a
+// new dashboard ever uses a colon or `]` in a name we will need to URL-
+// escape it here — for now the simple form keeps the wire shape readable
+// and the proxy parser trivially correct.
+const (
+	crMaskPrefix = "[CR_REDACTED:"
+	crMaskSuffix = "]"
+)
+
+func panelMaskValue(panelID int64, refID string) string {
+	return crMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + refID + crMaskSuffix
+}
+
+func variableMaskValue(name string) string {
+	return crMaskPrefix + "v:" + name + crMaskSuffix
 }
 
 // isCodeRabbitMFE reports whether the Grafana process is configured as the
@@ -49,10 +77,12 @@ func isCodeRabbitMFE() bool {
 // query strings on every panel target (including targets on panels nested
 // inside row panels) AND on every templating variable of type `query`
 // (where the SQL lives in `query` / `definition` on the variable itself).
-// The dashboard structure, panel/variable metadata and target metadata
-// (refId, datasource ref, hide flag, current selection, options, ...) are
-// left untouched so the frontend can still render the layout and the
-// variable picker.
+// Each redacted value carries a structural key (`[CR_REDACTED:p:<panelId>:<refId>]`
+// / `[CR_REDACTED:v:<varName>]`) that the CodeRabbit proxy uses to look the
+// original SQL up server-side. The dashboard structure, panel/variable
+// metadata and target metadata (refId, datasource ref, hide flag, current
+// selection, options, ...) are left untouched so the frontend can still
+// render the layout and the variable picker.
 func maskDashboardQueriesForMFE(data *simplejson.Json) {
 	if data == nil {
 		return
@@ -84,8 +114,12 @@ func maskPanelTargets(panel *simplejson.Json) {
 	if !ok {
 		return
 	}
+	panelID, _ := panel.Get("id").Int64()
 	for i := range targets.MustArray() {
-		maskRawQueryFields(targets.GetIndex(i))
+		target := targets.GetIndex(i)
+		refID, _ := target.Get("refId").String()
+		mask := panelMaskValue(panelID, refID)
+		maskRawQueryFields(target, mask)
 	}
 }
 
@@ -111,11 +145,13 @@ func maskTemplatingList(list *simplejson.Json) {
 		if varType != "query" {
 			continue
 		}
+		name, _ := var_.Get("name").String()
+		mask := variableMaskValue(name)
 
 		// `definition` is always a string snapshot of the SQL.
 		if def, ok := var_.CheckGet("definition"); ok {
 			if s, err := def.String(); err == nil && s != "" {
-				var_.Set("definition", crMaskedValue)
+				var_.Set("definition", mask)
 			}
 		}
 
@@ -126,23 +162,23 @@ func maskTemplatingList(list *simplejson.Json) {
 		if q, ok := var_.CheckGet("query"); ok {
 			if s, err := q.String(); err == nil {
 				if s != "" {
-					var_.Set("query", crMaskedValue)
+					var_.Set("query", mask)
 				}
 			} else if _, err := q.Map(); err == nil {
-				maskRawQueryFields(q)
+				maskRawQueryFields(q, mask)
 			}
 		}
 	}
 }
 
 // maskRawQueryFields replaces every string-valued raw-query field on the
-// given JSON object with the mask placeholder. Non-string values are left
-// untouched (e.g. influxdb's `rawQuery` boolean toggle).
-func maskRawQueryFields(obj *simplejson.Json) {
+// given JSON object with the supplied mask string. Non-string values are
+// left untouched (e.g. influxdb's `rawQuery` boolean toggle).
+func maskRawQueryFields(obj *simplejson.Json, mask string) {
 	for _, field := range crMaskedQueryFields {
 		if cur, ok := obj.CheckGet(field); ok {
 			if _, err := cur.String(); err == nil {
-				obj.Set(field, crMaskedValue)
+				obj.Set(field, mask)
 			}
 		}
 	}

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -9,17 +9,17 @@ import (
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
-// crMFEEnvVar is the environment variable that, when truthy, indicates that
+// mfeEnvVar is the environment variable that, when truthy, indicates that
 // Grafana is running as the CodeRabbit microfrontend (FNDashboard). When this
 // flag is on, dashboard JSON responses must not expose raw datasource queries
 // (e.g. SQL) to the browser — the backend resolves them at query time instead.
-const crMFEEnvVar = "GF_CR_MFE"
+const mfeEnvVar = "GF_MFE"
 
-// crMaskedQueryFields lists the JSON keys that carry raw, datasource-specific
+// mfeMaskedQueryFields lists the JSON keys that carry raw, datasource-specific
 // query text on a panel target. We mask these explicitly (rather than
 // whitelisting metadata) so that unknown datasources keep their structure and
 // the frontend can still render the panel layout.
-var crMaskedQueryFields = []string{
+var mfeMaskedQueryFields = []string{
 	"rawSql",    // postgres, mysql, mssql
 	"expr",      // prometheus, loki
 	"query",     // elasticsearch, influxdb, cloudwatch, generic
@@ -30,7 +30,7 @@ var crMaskedQueryFields = []string{
 
 // Redacted value prefix and tag format. The frontend forwards the masked
 // rawSql verbatim to `/api/ds/query`; the CodeRabbit proxy recognises the
-// `[CR_REDACTED:...]` shape, decodes the key, looks the original SQL up in
+// `[MFE_REDACTED:...]` shape, decodes the key, looks the original SQL up in
 // its own indexed dashboard JSON copy, substitutes variables + macros and
 // forwards a resolved query upstream. The structure carries everything
 // needed for the lookup so we don't have to introduce an alternate body
@@ -38,8 +38,8 @@ var crMaskedQueryFields = []string{
 //
 // Encoding (URL-safe — colons are the only delimiter):
 //
-//	panel target:        [CR_REDACTED:p:<panelId>:<refId>]
-//	templating variable: [CR_REDACTED:v:<variableName>]
+//	panel target:        [MFE_REDACTED:p:<panelId>:<refId>]
+//	templating variable: [MFE_REDACTED:v:<variableName>]
 //
 // `<refId>` and `<variableName>` are pulled directly from the dashboard JSON.
 // They are URL-query-encoded (`net/url.QueryEscape`) before concatenation so
@@ -47,23 +47,23 @@ var crMaskedQueryFields = []string{
 // unambiguously recovered by the proxy. The proxy decodes each segment via
 // the inverse `decodeURIComponent`.
 const (
-	crMaskPrefix = "[CR_REDACTED:"
-	crMaskSuffix = "]"
+	mfeMaskPrefix = "[MFE_REDACTED:"
+	mfeMaskSuffix = "]"
 )
 
 func panelMaskValue(panelID int64, refID string) string {
-	return crMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + url.QueryEscape(refID) + crMaskSuffix
+	return mfeMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + url.QueryEscape(refID) + mfeMaskSuffix
 }
 
 func variableMaskValue(name string) string {
-	return crMaskPrefix + "v:" + url.QueryEscape(name) + crMaskSuffix
+	return mfeMaskPrefix + "v:" + url.QueryEscape(name) + mfeMaskSuffix
 }
 
 // isCodeRabbitMFE reports whether the Grafana process is configured as the
 // CodeRabbit microfrontend. The env var is considered enabled when set to any
 // of the common truthy strings ("1", "true", "yes", case-insensitive).
 func isCodeRabbitMFE() bool {
-	v, ok := os.LookupEnv(crMFEEnvVar)
+	v, ok := os.LookupEnv(mfeEnvVar)
 	if !ok {
 		return false
 	}
@@ -78,8 +78,8 @@ func isCodeRabbitMFE() bool {
 // query strings on every panel target (including targets on panels nested
 // inside row panels) AND on every templating variable of type `query`
 // (where the SQL lives in `query` / `definition` on the variable itself).
-// Each redacted value carries a structural key (`[CR_REDACTED:p:<panelId>:<refId>]`
-// / `[CR_REDACTED:v:<varName>]`) that the CodeRabbit proxy uses to look the
+// Each redacted value carries a structural key (`[MFE_REDACTED:p:<panelId>:<refId>]`
+// / `[MFE_REDACTED:v:<varName>]`) that the CodeRabbit proxy uses to look the
 // original SQL up server-side. The dashboard structure, panel/variable
 // metadata and target metadata (refId, datasource ref, hide flag, current
 // selection, options, ...) are left untouched so the frontend can still
@@ -176,7 +176,7 @@ func maskTemplatingList(list *simplejson.Json) {
 // given JSON object with the supplied mask string. Non-string values are
 // left untouched (e.g. influxdb's `rawQuery` boolean toggle).
 func maskRawQueryFields(obj *simplejson.Json, mask string) {
-	for _, field := range crMaskedQueryFields {
+	for _, field := range mfeMaskedQueryFields {
 		if cur, ok := obj.CheckGet(field); ok {
 			if _, err := cur.String(); err == nil {
 				obj.Set(field, mask)

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+
 	"github.com/grafana/grafana/pkg/components/simplejson"
 )
 
@@ -191,6 +193,41 @@ func maskRawQueryFields(obj *simplejson.Json, mask string) {
 			if _, err := cur.String(); err == nil {
 				obj.Set(field, mask)
 			}
+		}
+	}
+}
+
+// maskExecutedQueriesForMFE blanks every `frame.Meta.ExecutedQueryString`
+// in a /api/ds/query response. The datasource backend stamps this field
+// with the SQL / PromQL / KQL / ... it actually ran (with all variables
+// and macros resolved), which is exactly what we masked out of the
+// dashboard JSON on the way out — surfacing it on the response would
+// defeat the masking. The Query Inspector consumes this field via
+// `frame.meta.executedQueryString`; blanking the string causes it to
+// hide the per-frame "Executed query" panel (see
+// public/app/features/inspector/QueryInspector.tsx).
+//
+// Notes:
+//   - We do NOT drop the frame, refId, or response shape; only the
+//     executed-query text is removed, so panels still render.
+//   - Per-frame error messages, stats, notices and Custom datasource
+//     metadata are left intact. Datasources that copy the executed
+//     query into their own Custom payload (e.g. cloudwatch / influxdb)
+//     are not currently masked here; if that becomes a leak, extend
+//     this helper rather than introducing a parallel masker.
+func maskExecutedQueriesForMFE(resp *backend.QueryDataResponse) {
+	if resp == nil {
+		return
+	}
+	for _, r := range resp.Responses {
+		for i := range r.Frames {
+			if r.Frames[i] == nil || r.Frames[i].Meta == nil {
+				continue
+			}
+			// Frames is a []*data.Frame slice so mutations through the
+			// pointer are visible to the caller without re-assigning the
+			// backend.DataResponse value back into resp.Responses.
+			r.Frames[i].Meta.ExecutedQueryString = ""
 		}
 	}
 }

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -40,22 +41,22 @@ var crMaskedQueryFields = []string{
 //	panel target:        [CR_REDACTED:p:<panelId>:<refId>]
 //	templating variable: [CR_REDACTED:v:<variableName>]
 //
-// `<refId>` and `<variableName>` are pulled directly from the dashboard
-// JSON. Their character set in shipped dashboards is `[A-Za-z0-9_-]`; if a
-// new dashboard ever uses a colon or `]` in a name we will need to URL-
-// escape it here — for now the simple form keeps the wire shape readable
-// and the proxy parser trivially correct.
+// `<refId>` and `<variableName>` are pulled directly from the dashboard JSON.
+// They are URL-query-encoded (`net/url.QueryEscape`) before concatenation so
+// that names containing the structural delimiters `:` or `]` can still be
+// unambiguously recovered by the proxy. The proxy decodes each segment via
+// the inverse `decodeURIComponent`.
 const (
 	crMaskPrefix = "[CR_REDACTED:"
 	crMaskSuffix = "]"
 )
 
 func panelMaskValue(panelID int64, refID string) string {
-	return crMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + refID + crMaskSuffix
+	return crMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + url.QueryEscape(refID) + crMaskSuffix
 }
 
 func variableMaskValue(name string) string {
-	return crMaskPrefix + "v:" + name + crMaskSuffix
+	return crMaskPrefix + "v:" + url.QueryEscape(name) + crMaskSuffix
 }
 
 // isCodeRabbitMFE reports whether the Grafana process is configured as the

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"os"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+// crMFEEnvVar is the environment variable that, when truthy, indicates that
+// Grafana is running as the CodeRabbit microfrontend (FNDashboard). When this
+// flag is on, dashboard JSON responses must not expose raw datasource queries
+// (e.g. SQL) to the browser — the backend resolves them at query time instead.
+const crMFEEnvVar = "GF_CR_MFE"
+
+// crMaskedValue is the placeholder substituted in place of any raw query text
+// when running as the CodeRabbit microfrontend.
+const crMaskedValue = "[REDACTED]"
+
+// crMaskedQueryFields lists the JSON keys that carry raw, datasource-specific
+// query text on a panel target. We mask these explicitly (rather than
+// whitelisting metadata) so that unknown datasources keep their structure and
+// the frontend can still render the panel layout.
+var crMaskedQueryFields = []string{
+	"rawSql",    // postgres, mysql, mssql
+	"expr",      // prometheus, loki
+	"query",     // elasticsearch, influxdb, cloudwatch, generic
+	"rawQuery",  // azure monitor, influxdb (toggle key elsewhere — we mask string values only)
+	"queryText", // bigquery, snowflake, athena
+	"target",    // graphite
+}
+
+// isCodeRabbitMFE reports whether the Grafana process is configured as the
+// CodeRabbit microfrontend. The env var is considered enabled when set to any
+// of the common truthy strings ("1", "true", "yes", case-insensitive).
+func isCodeRabbitMFE() bool {
+	v, ok := os.LookupEnv(crMFEEnvVar)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// maskDashboardQueriesForMFE walks the dashboard JSON and redacts any raw
+// query strings on every panel target (including targets on panels nested
+// inside row panels). The dashboard structure, panel metadata and target
+// metadata (refId, datasource ref, hide flag, ...) are left untouched so the
+// frontend can still render the layout.
+func maskDashboardQueriesForMFE(data *simplejson.Json) {
+	if data == nil {
+		return
+	}
+	panels, ok := data.CheckGet("panels")
+	if !ok {
+		return
+	}
+	maskPanelArray(panels)
+}
+
+func maskPanelArray(panels *simplejson.Json) {
+	for i := range panels.MustArray() {
+		panel := panels.GetIndex(i)
+		maskPanelTargets(panel)
+
+		// Row panels embed their child panels under a nested "panels" array.
+		if nested, ok := panel.CheckGet("panels"); ok {
+			maskPanelArray(nested)
+		}
+	}
+}
+
+func maskPanelTargets(panel *simplejson.Json) {
+	targets, ok := panel.CheckGet("targets")
+	if !ok {
+		return
+	}
+	for i := range targets.MustArray() {
+		target := targets.GetIndex(i)
+		for _, field := range crMaskedQueryFields {
+			if cur, ok := target.CheckGet(field); ok {
+				// Only mask string-valued fields. Booleans like influxdb's
+				// `rawQuery` (a UI toggle) must keep their type.
+				if _, err := cur.String(); err == nil {
+					target.Set(field, crMaskedValue)
+				}
+			}
+		}
+	}
+}

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -41,22 +41,32 @@ var mfeMaskedQueryFields = []string{
 //	panel target:        [MFE_REDACTED:p:<panelId>:<refId>]
 //	templating variable: [MFE_REDACTED:v:<variableName>]
 //
-// `<refId>` and `<variableName>` are pulled directly from the dashboard JSON.
-// They are URL-query-encoded (`net/url.QueryEscape`) before concatenation so
-// that names containing the structural delimiters `:` or `]` can still be
-// unambiguously recovered by the proxy. The proxy decodes each segment via
-// the inverse `decodeURIComponent`.
+// `<refId>` and `<variableName>` are pulled directly from the dashboard JSON
+// and percent-encoded before concatenation so that names containing the
+// structural delimiters `:` or `]` (or any non-ASCII / reserved characters)
+// can still be unambiguously recovered by the proxy. The proxy decodes each
+// segment via the inverse `decodeURIComponent`, which treats `+` as a literal
+// `+` rather than a space — so we cannot use `net/url.QueryEscape` directly
+// (it encodes spaces as `+`). `mfeEncodeMaskSegment` produces `%20`-style
+// encoding compatible with `decodeURIComponent`.
 const (
 	mfeMaskPrefix = "[MFE_REDACTED:"
 	mfeMaskSuffix = "]"
 )
 
+// mfeEncodeMaskSegment percent-encodes a refID / variable name for embedding
+// in a redaction marker. The output is compatible with the proxy's
+// `decodeURIComponent` decoder: spaces become `%20`, not `+`.
+func mfeEncodeMaskSegment(s string) string {
+	return strings.ReplaceAll(url.QueryEscape(s), "+", "%20")
+}
+
 func panelMaskValue(panelID int64, refID string) string {
-	return mfeMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + url.QueryEscape(refID) + mfeMaskSuffix
+	return mfeMaskPrefix + "p:" + strconv.FormatInt(panelID, 10) + ":" + mfeEncodeMaskSegment(refID) + mfeMaskSuffix
 }
 
 func variableMaskValue(name string) string {
-	return mfeMaskPrefix + "v:" + url.QueryEscape(name) + mfeMaskSuffix
+	return mfeMaskPrefix + "v:" + mfeEncodeMaskSegment(name) + mfeMaskSuffix
 }
 
 // isCodeRabbitMFE reports whether the Grafana process is configured as the
@@ -128,9 +138,9 @@ func maskPanelTargets(panel *simplejson.Json) {
 // redacts the SQL on every `query`-type variable. The Grafana JSON stores
 // the SQL in two places:
 //
-//	- `definition`: always a plain string snapshot used by the variable picker.
-//	- `query`: either a plain string (legacy / our shipped dashboards) OR an
-//	  object of the same shape as a panel target (`rawSql`, `expr`, ...).
+//   - `definition`: always a plain string snapshot used by the variable picker.
+//   - `query`: either a plain string (legacy / our shipped dashboards) OR an
+//     object of the same shape as a panel target (`rawSql`, `expr`, ...).
 //
 // We mask both forms so the redaction is robust to future dashboards saved
 // from a newer Grafana UI that prefers the object form.

--- a/pkg/api/dashboard_mfe_mask.go
+++ b/pkg/api/dashboard_mfe_mask.go
@@ -47,18 +47,24 @@ func isCodeRabbitMFE() bool {
 
 // maskDashboardQueriesForMFE walks the dashboard JSON and redacts any raw
 // query strings on every panel target (including targets on panels nested
-// inside row panels). The dashboard structure, panel metadata and target
-// metadata (refId, datasource ref, hide flag, ...) are left untouched so the
-// frontend can still render the layout.
+// inside row panels) AND on every templating variable of type `query`
+// (where the SQL lives in `query` / `definition` on the variable itself).
+// The dashboard structure, panel/variable metadata and target metadata
+// (refId, datasource ref, hide flag, current selection, options, ...) are
+// left untouched so the frontend can still render the layout and the
+// variable picker.
 func maskDashboardQueriesForMFE(data *simplejson.Json) {
 	if data == nil {
 		return
 	}
-	panels, ok := data.CheckGet("panels")
-	if !ok {
-		return
+	if panels, ok := data.CheckGet("panels"); ok {
+		maskPanelArray(panels)
 	}
-	maskPanelArray(panels)
+	if templating, ok := data.CheckGet("templating"); ok {
+		if list, ok := templating.CheckGet("list"); ok {
+			maskTemplatingList(list)
+		}
+	}
 }
 
 func maskPanelArray(panels *simplejson.Json) {
@@ -79,14 +85,64 @@ func maskPanelTargets(panel *simplejson.Json) {
 		return
 	}
 	for i := range targets.MustArray() {
-		target := targets.GetIndex(i)
-		for _, field := range crMaskedQueryFields {
-			if cur, ok := target.CheckGet(field); ok {
-				// Only mask string-valued fields. Booleans like influxdb's
-				// `rawQuery` (a UI toggle) must keep their type.
-				if _, err := cur.String(); err == nil {
-					target.Set(field, crMaskedValue)
+		maskRawQueryFields(targets.GetIndex(i))
+	}
+}
+
+// maskTemplatingList walks the dashboard's templating variable list and
+// redacts the SQL on every `query`-type variable. The Grafana JSON stores
+// the SQL in two places:
+//
+//	- `definition`: always a plain string snapshot used by the variable picker.
+//	- `query`: either a plain string (legacy / our shipped dashboards) OR an
+//	  object of the same shape as a panel target (`rawSql`, `expr`, ...).
+//
+// We mask both forms so the redaction is robust to future dashboards saved
+// from a newer Grafana UI that prefers the object form.
+func maskTemplatingList(list *simplejson.Json) {
+	for i := range list.MustArray() {
+		var_ := list.GetIndex(i)
+
+		// Only `query`-type variables carry real SQL. `custom`, `textbox`,
+		// `interval` and `datasource` variables either have no `query` field
+		// or carry a comma-separated literal list / placeholder string — none
+		// of which constitute datasource-backed query text we need to hide.
+		varType, _ := var_.Get("type").String()
+		if varType != "query" {
+			continue
+		}
+
+		// `definition` is always a string snapshot of the SQL.
+		if def, ok := var_.CheckGet("definition"); ok {
+			if s, err := def.String(); err == nil && s != "" {
+				var_.Set("definition", crMaskedValue)
+			}
+		}
+
+		// `query` is either a string (mask it directly) or an object that
+		// follows the same shape as a panel target (mask its rawSql / expr /
+		// ... fields). Empty strings are left alone so the shape stays
+		// recognisably "no query" rather than "redacted query".
+		if q, ok := var_.CheckGet("query"); ok {
+			if s, err := q.String(); err == nil {
+				if s != "" {
+					var_.Set("query", crMaskedValue)
 				}
+			} else if _, err := q.Map(); err == nil {
+				maskRawQueryFields(q)
+			}
+		}
+	}
+}
+
+// maskRawQueryFields replaces every string-valued raw-query field on the
+// given JSON object with the mask placeholder. Non-string values are left
+// untouched (e.g. influxdb's `rawQuery` boolean toggle).
+func maskRawQueryFields(obj *simplejson.Json) {
+	for _, field := range crMaskedQueryFields {
+		if cur, ok := obj.CheckGet(field); ok {
+			if _, err := cur.String(); err == nil {
+				obj.Set(field, crMaskedValue)
 			}
 		}
 	}

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -295,4 +297,106 @@ func TestPanelAndVariableMaskValueRoundTripsSpaces(t *testing.T) {
 	variable := variableMaskValue(varName)
 	assert.Equal(t, "[MFE_REDACTED:v:org%20name]", variable)
 	assert.NotContains(t, variable, "+", "spaces must be %20-encoded, not `+`")
+}
+
+func TestMaskExecutedQueriesForMFE(t *testing.T) {
+	t.Run("blanks ExecutedQueryString on every frame across every refId", func(t *testing.T) {
+		resp := &backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{
+						&data.Frame{Meta: &data.FrameMeta{ExecutedQueryString: "SELECT 1 FROM tenants WHERE org_id = 'abc'"}},
+						&data.Frame{Meta: &data.FrameMeta{ExecutedQueryString: "SELECT 2"}},
+					},
+				},
+				"B": backend.DataResponse{
+					Frames: data.Frames{
+						&data.Frame{Meta: &data.FrameMeta{ExecutedQueryString: "Expr: up{org=\"abc\"}"}},
+					},
+				},
+			},
+		}
+
+		maskExecutedQueriesForMFE(resp)
+
+		for refID, r := range resp.Responses {
+			for i, frame := range r.Frames {
+				require.NotNil(t, frame.Meta, "refId=%s frame=%d meta should still exist", refID, i)
+				assert.Empty(t, frame.Meta.ExecutedQueryString, "refId=%s frame=%d", refID, i)
+			}
+		}
+	})
+
+	t.Run("preserves frame data, meta-other-fields, errors and stats", func(t *testing.T) {
+		custom := map[string]string{"shard": "1"}
+		resp := &backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{
+						&data.Frame{
+							Name:   "series",
+							RefID:  "A",
+							Fields: []*data.Field{data.NewField("v", nil, []float64{1, 2, 3})},
+							Meta: &data.FrameMeta{
+								ExecutedQueryString: "SELECT secret FROM t",
+								Custom:              custom,
+								Stats:               []data.QueryStat{{FieldConfig: data.FieldConfig{DisplayName: "rows"}, Value: 3}},
+								Notices:             []data.Notice{{Text: "ok"}},
+							},
+						},
+					},
+					Status: backend.StatusOK,
+				},
+			},
+		}
+
+		maskExecutedQueriesForMFE(resp)
+
+		frame := resp.Responses["A"].Frames[0]
+		assert.Empty(t, frame.Meta.ExecutedQueryString)
+		assert.Equal(t, custom, frame.Meta.Custom, "Custom datasource metadata must survive")
+		assert.Len(t, frame.Meta.Stats, 1, "Stats must survive")
+		assert.Len(t, frame.Meta.Notices, 1, "Notices must survive")
+		assert.Equal(t, "series", frame.Name)
+		assert.Equal(t, "A", frame.RefID)
+		require.Len(t, frame.Fields, 1)
+		assert.Equal(t, 3, frame.Fields[0].Len())
+	})
+
+	t.Run("nil response is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { maskExecutedQueriesForMFE(nil) })
+	})
+
+	t.Run("frames with nil Meta are skipped without panicking", func(t *testing.T) {
+		resp := &backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{
+						&data.Frame{}, // no Meta
+						&data.Frame{Meta: &data.FrameMeta{ExecutedQueryString: "x"}},
+					},
+				},
+			},
+		}
+
+		assert.NotPanics(t, func() { maskExecutedQueriesForMFE(resp) })
+		assert.Nil(t, resp.Responses["A"].Frames[0].Meta)
+		assert.Empty(t, resp.Responses["A"].Frames[1].Meta.ExecutedQueryString)
+	})
+
+	t.Run("nil frame entries are skipped without panicking", func(t *testing.T) {
+		resp := &backend.QueryDataResponse{
+			Responses: backend.Responses{
+				"A": backend.DataResponse{
+					Frames: data.Frames{
+						nil,
+						&data.Frame{Meta: &data.FrameMeta{ExecutedQueryString: "x"}},
+					},
+				},
+			},
+		}
+
+		assert.NotPanics(t, func() { maskExecutedQueriesForMFE(resp) })
+		assert.Empty(t, resp.Responses["A"].Frames[1].Meta.ExecutedQueryString)
+	})
 }

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"net/url"
 	"os"
 	"testing"
 
@@ -250,4 +251,48 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		assert.Equal(t, "[MFE_REDACTED:v:weird%3Aname%5Dthing]", v.Get("query").MustString())
 		assert.Equal(t, "[MFE_REDACTED:v:weird%3Aname%5Dthing]", v.Get("definition").MustString())
 	})
+}
+
+// TestMfeEncodeMaskSegment ensures that mask segments are encoded with
+// %20-style escapes (not the form-encoded `+` produced by url.QueryEscape).
+// The proxy decodes each segment with `decodeURIComponent`, which preserves
+// `+` literally — so emitting `+` for space here would break the round-trip
+// for refIDs / variable names containing spaces.
+func TestMfeEncodeMaskSegment(t *testing.T) {
+	cases := map[string]string{
+		"":             "",
+		"A":            "A",
+		"foo bar":      "foo%20bar",
+		"hello world!": "hello%20world%21",
+		"a+b":          "a%2Bb",
+		"a:b]c":        "a%3Ab%5Dc",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, mfeEncodeMaskSegment(in))
+			// Round-trip via the same decoder the proxy uses
+			// (Go's url.QueryUnescape is `%`-aware and treats `+` as space —
+			// equivalent enough for this property when no literal `+` remains).
+			decoded, err := url.QueryUnescape(mfeEncodeMaskSegment(in))
+			require.NoError(t, err)
+			assert.Equal(t, in, decoded)
+		})
+	}
+}
+
+// TestPanelAndVariableMaskValueRoundTripsSpaces verifies that refIDs and
+// variable names containing spaces survive the marker round-trip end-to-end:
+// the produced marker must decode (per decodeURIComponent semantics, which
+// only handles `%xx`) back to the original name.
+func TestPanelAndVariableMaskValueRoundTripsSpaces(t *testing.T) {
+	refID := "foo bar"
+	varName := "org name"
+
+	panel := panelMaskValue(42, refID)
+	assert.Equal(t, "[MFE_REDACTED:p:42:foo%20bar]", panel)
+	assert.NotContains(t, panel, "+", "spaces must be %20-encoded, not `+`")
+
+	variable := variableMaskValue(varName)
+	assert.Equal(t, "[MFE_REDACTED:v:org%20name]", variable)
+	assert.NotContains(t, variable, "+", "spaces must be %20-encoded, not `+`")
 }

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -128,6 +128,77 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		assert.Equal(t, "empty", data.Get("title").MustString())
 	})
 
+	t.Run("masks templating variable queries (string form)", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [],
+			"templating": {
+				"list": [
+					{
+						"name": "org_name",
+						"type": "query",
+						"query": "SELECT name FROM orgs WHERE id = $id",
+						"definition": "SELECT name FROM orgs WHERE id = $id",
+						"current": {"text": "All", "value": "$__all"},
+						"options": [{"text": "All", "value": "$__all"}]
+					},
+					{
+						"name": "self_hosted_id",
+						"type": "custom",
+						"query": "",
+						"current": {"text": "All", "value": "$__all"}
+					}
+				]
+			}
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		vars := data.Get("templating").Get("list")
+		orgName := vars.GetIndex(0)
+		assert.Equal(t, "[REDACTED]", orgName.Get("query").MustString())
+		assert.Equal(t, "[REDACTED]", orgName.Get("definition").MustString())
+		// Variable metadata (name, current selection, options) must be preserved
+		// so the frontend variable picker can still render.
+		assert.Equal(t, "org_name", orgName.Get("name").MustString())
+		assert.Equal(t, "All", orgName.Get("current").Get("text").MustString())
+		// `custom`-type vars carry an empty `query` (not real SQL); masking it
+		// with the placeholder is acceptable because the picker keys off
+		// `options` / `current`, not `query`. But ensure the empty string isn't
+		// overwritten with REDACTED — there is no SQL to hide.
+		selfHosted := vars.GetIndex(1)
+		assert.Equal(t, "", selfHosted.Get("query").MustString())
+	})
+
+	t.Run("masks templating variable queries (object form)", func(t *testing.T) {
+		raw := []byte(`{
+			"templating": {
+				"list": [
+					{
+						"name": "repo_name",
+						"type": "query",
+						"query": {
+							"refId": "repo_name",
+							"rawSql": "SELECT repository_name FROM repositories WHERE org_id = $org_id"
+						},
+						"definition": "SELECT repository_name FROM repositories WHERE org_id = $org_id"
+					}
+				]
+			}
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		v := data.Get("templating").Get("list").GetIndex(0)
+		assert.Equal(t, "[REDACTED]", v.Get("definition").MustString())
+		assert.Equal(t, "[REDACTED]", v.Get("query").Get("rawSql").MustString())
+		// refId is metadata — keep it.
+		assert.Equal(t, "repo_name", v.Get("query").Get("refId").MustString())
+	})
+
 	t.Run("nil dashboard is a no-op", func(t *testing.T) {
 		assert.NotPanics(t, func() { maskDashboardQueriesForMFE(nil) })
 	})

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+func TestIsCodeRabbitMFE(t *testing.T) {
+	cases := map[string]bool{
+		"":      false,
+		"0":     false,
+		"false": false,
+		"no":    false,
+		"off":   false,
+		"1":     true,
+		"true":  true,
+		"True":  true,
+		"yes":   true,
+		"on":    true,
+		" 1 ":   true,
+	}
+	for value, want := range cases {
+		t.Run(value, func(t *testing.T) {
+			if value == "" {
+				t.Setenv(crMFEEnvVar, "")
+			} else {
+				t.Setenv(crMFEEnvVar, value)
+			}
+			assert.Equal(t, want, isCodeRabbitMFE())
+		})
+	}
+
+	t.Run("unset", func(t *testing.T) {
+		// t.Setenv only restores; we want to test the missing-key path explicitly.
+		// The "" case above already sets it to empty (still present), so verify
+		// the LookupEnv-not-ok path by relying on the default test environment
+		// where the var is not set.
+		// (No-op sanity assertion — the value above covers the truthy parsing.)
+		assert.False(t, isCodeRabbitMFE() && false)
+	})
+}
+
+func TestMaskDashboardQueriesForMFE(t *testing.T) {
+	t.Run("masks raw query fields on flat panels", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [
+				{
+					"id": 1,
+					"type": "timeseries",
+					"targets": [
+						{"refId": "A", "rawSql": "SELECT * FROM users", "format": "time_series"},
+						{"refId": "B", "expr":  "sum(rate(http_requests_total[5m]))"},
+						{"refId": "C", "query": "stats count() by host"}
+					]
+				}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		targets := data.Get("panels").GetIndex(0).Get("targets")
+		assert.Equal(t, "[REDACTED]", targets.GetIndex(0).Get("rawSql").MustString())
+		assert.Equal(t, "A", targets.GetIndex(0).Get("refId").MustString())
+		assert.Equal(t, "time_series", targets.GetIndex(0).Get("format").MustString())
+		assert.Equal(t, "[REDACTED]", targets.GetIndex(1).Get("expr").MustString())
+		assert.Equal(t, "[REDACTED]", targets.GetIndex(2).Get("query").MustString())
+	})
+
+	t.Run("recurses into row panels", func(t *testing.T) {
+		raw := []byte(`{
+			"panels": [
+				{
+					"id": 1,
+					"type": "row",
+					"panels": [
+						{"id": 2, "type": "timeseries", "targets": [{"refId": "A", "rawSql": "SELECT 1"}]}
+					]
+				}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		nested := data.Get("panels").GetIndex(0).Get("panels").GetIndex(0)
+		assert.Equal(t, "[REDACTED]", nested.Get("targets").GetIndex(0).Get("rawSql").MustString())
+	})
+
+	t.Run("leaves non-string fields untouched", func(t *testing.T) {
+		// influxdb uses `rawQuery` as a boolean toggle on its UI model; we must
+		// not coerce booleans into strings.
+		raw := []byte(`{
+			"panels": [
+				{
+					"id": 1,
+					"targets": [
+						{"refId": "A", "rawQuery": true,  "query": "SELECT 1"}
+					]
+				}
+			]
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		target := data.Get("panels").GetIndex(0).Get("targets").GetIndex(0)
+		// boolean stays boolean
+		raw_q, err := target.Get("rawQuery").Bool()
+		assert.NoError(t, err)
+		assert.True(t, raw_q)
+		// string `query` is masked
+		assert.Equal(t, "[REDACTED]", target.Get("query").MustString())
+	})
+
+	t.Run("no-op when there are no panels", func(t *testing.T) {
+		data, err := simplejson.NewJson([]byte(`{"title": "empty"}`))
+		require.NoError(t, err)
+		// must not panic
+		maskDashboardQueriesForMFE(data)
+		assert.Equal(t, "empty", data.Get("title").MustString())
+	})
+
+	t.Run("nil dashboard is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() { maskDashboardQueriesForMFE(nil) })
+	})
+}

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -65,11 +65,11 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		targets := data.Get("panels").GetIndex(0).Get("targets")
-		assert.Equal(t, "[REDACTED]", targets.GetIndex(0).Get("rawSql").MustString())
+		assert.Equal(t, "[CR_REDACTED:p:1:A]", targets.GetIndex(0).Get("rawSql").MustString())
 		assert.Equal(t, "A", targets.GetIndex(0).Get("refId").MustString())
 		assert.Equal(t, "time_series", targets.GetIndex(0).Get("format").MustString())
-		assert.Equal(t, "[REDACTED]", targets.GetIndex(1).Get("expr").MustString())
-		assert.Equal(t, "[REDACTED]", targets.GetIndex(2).Get("query").MustString())
+		assert.Equal(t, "[CR_REDACTED:p:1:B]", targets.GetIndex(1).Get("expr").MustString())
+		assert.Equal(t, "[CR_REDACTED:p:1:C]", targets.GetIndex(2).Get("query").MustString())
 	})
 
 	t.Run("recurses into row panels", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		nested := data.Get("panels").GetIndex(0).Get("panels").GetIndex(0)
-		assert.Equal(t, "[REDACTED]", nested.Get("targets").GetIndex(0).Get("rawSql").MustString())
+		assert.Equal(t, "[CR_REDACTED:p:2:A]", nested.Get("targets").GetIndex(0).Get("rawSql").MustString())
 	})
 
 	t.Run("leaves non-string fields untouched", func(t *testing.T) {
@@ -117,7 +117,7 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, raw_q)
 		// string `query` is masked
-		assert.Equal(t, "[REDACTED]", target.Get("query").MustString())
+		assert.Equal(t, "[CR_REDACTED:p:1:A]", target.Get("query").MustString())
 	})
 
 	t.Run("no-op when there are no panels", func(t *testing.T) {
@@ -157,8 +157,8 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 
 		vars := data.Get("templating").Get("list")
 		orgName := vars.GetIndex(0)
-		assert.Equal(t, "[REDACTED]", orgName.Get("query").MustString())
-		assert.Equal(t, "[REDACTED]", orgName.Get("definition").MustString())
+		assert.Equal(t, "[CR_REDACTED:v:org_name]", orgName.Get("query").MustString())
+		assert.Equal(t, "[CR_REDACTED:v:org_name]", orgName.Get("definition").MustString())
 		// Variable metadata (name, current selection, options) must be preserved
 		// so the frontend variable picker can still render.
 		assert.Equal(t, "org_name", orgName.Get("name").MustString())
@@ -193,8 +193,8 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		v := data.Get("templating").Get("list").GetIndex(0)
-		assert.Equal(t, "[REDACTED]", v.Get("definition").MustString())
-		assert.Equal(t, "[REDACTED]", v.Get("query").Get("rawSql").MustString())
+		assert.Equal(t, "[CR_REDACTED:v:repo_name]", v.Get("definition").MustString())
+		assert.Equal(t, "[CR_REDACTED:v:repo_name]", v.Get("query").Get("rawSql").MustString())
 		// refId is metadata — keep it.
 		assert.Equal(t, "repo_name", v.Get("query").Get("refId").MustString())
 	})

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -27,9 +27,9 @@ func TestIsCodeRabbitMFE(t *testing.T) {
 	for value, want := range cases {
 		t.Run(value, func(t *testing.T) {
 			if value == "" {
-				t.Setenv(crMFEEnvVar, "")
+				t.Setenv(mfeEnvVar, "")
 			} else {
-				t.Setenv(crMFEEnvVar, value)
+				t.Setenv(mfeEnvVar, value)
 			}
 			assert.Equal(t, want, isCodeRabbitMFE())
 		})
@@ -39,13 +39,13 @@ func TestIsCodeRabbitMFE(t *testing.T) {
 		// Exercise the LookupEnv-not-ok path explicitly: clear the env var,
 		// remember whether the test environment had it set, and restore that
 		// state via t.Cleanup so we don't leak the change to other subtests.
-		old, existed := os.LookupEnv(crMFEEnvVar)
-		require.NoError(t, os.Unsetenv(crMFEEnvVar))
+		old, existed := os.LookupEnv(mfeEnvVar)
+		require.NoError(t, os.Unsetenv(mfeEnvVar))
 		t.Cleanup(func() {
 			if existed {
-				require.NoError(t, os.Setenv(crMFEEnvVar, old))
+				require.NoError(t, os.Setenv(mfeEnvVar, old))
 			} else {
-				require.NoError(t, os.Unsetenv(crMFEEnvVar))
+				require.NoError(t, os.Unsetenv(mfeEnvVar))
 			}
 		})
 
@@ -74,11 +74,11 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		targets := data.Get("panels").GetIndex(0).Get("targets")
-		assert.Equal(t, "[CR_REDACTED:p:1:A]", targets.GetIndex(0).Get("rawSql").MustString())
+		assert.Equal(t, "[MFE_REDACTED:p:1:A]", targets.GetIndex(0).Get("rawSql").MustString())
 		assert.Equal(t, "A", targets.GetIndex(0).Get("refId").MustString())
 		assert.Equal(t, "time_series", targets.GetIndex(0).Get("format").MustString())
-		assert.Equal(t, "[CR_REDACTED:p:1:B]", targets.GetIndex(1).Get("expr").MustString())
-		assert.Equal(t, "[CR_REDACTED:p:1:C]", targets.GetIndex(2).Get("query").MustString())
+		assert.Equal(t, "[MFE_REDACTED:p:1:B]", targets.GetIndex(1).Get("expr").MustString())
+		assert.Equal(t, "[MFE_REDACTED:p:1:C]", targets.GetIndex(2).Get("query").MustString())
 	})
 
 	t.Run("recurses into row panels", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		nested := data.Get("panels").GetIndex(0).Get("panels").GetIndex(0)
-		assert.Equal(t, "[CR_REDACTED:p:2:A]", nested.Get("targets").GetIndex(0).Get("rawSql").MustString())
+		assert.Equal(t, "[MFE_REDACTED:p:2:A]", nested.Get("targets").GetIndex(0).Get("rawSql").MustString())
 	})
 
 	t.Run("leaves non-string fields untouched", func(t *testing.T) {
@@ -126,7 +126,7 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, raw_q)
 		// string `query` is masked
-		assert.Equal(t, "[CR_REDACTED:p:1:A]", target.Get("query").MustString())
+		assert.Equal(t, "[MFE_REDACTED:p:1:A]", target.Get("query").MustString())
 	})
 
 	t.Run("no-op when there are no panels", func(t *testing.T) {
@@ -166,8 +166,8 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 
 		vars := data.Get("templating").Get("list")
 		orgName := vars.GetIndex(0)
-		assert.Equal(t, "[CR_REDACTED:v:org_name]", orgName.Get("query").MustString())
-		assert.Equal(t, "[CR_REDACTED:v:org_name]", orgName.Get("definition").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:org_name]", orgName.Get("query").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:org_name]", orgName.Get("definition").MustString())
 		// Variable metadata (name, current selection, options) must be preserved
 		// so the frontend variable picker can still render.
 		assert.Equal(t, "org_name", orgName.Get("name").MustString())
@@ -202,8 +202,8 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		v := data.Get("templating").Get("list").GetIndex(0)
-		assert.Equal(t, "[CR_REDACTED:v:repo_name]", v.Get("definition").MustString())
-		assert.Equal(t, "[CR_REDACTED:v:repo_name]", v.Get("query").Get("rawSql").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:repo_name]", v.Get("definition").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:repo_name]", v.Get("query").Get("rawSql").MustString())
 		// refId is metadata — keep it.
 		assert.Equal(t, "repo_name", v.Get("query").Get("refId").MustString())
 	})
@@ -244,10 +244,10 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 		maskDashboardQueriesForMFE(data)
 
 		panelMask := data.Get("panels").GetIndex(0).Get("targets").GetIndex(0).Get("rawSql").MustString()
-		assert.Equal(t, "[CR_REDACTED:p:7:A%3AB%5DC]", panelMask)
+		assert.Equal(t, "[MFE_REDACTED:p:7:A%3AB%5DC]", panelMask)
 
 		v := data.Get("templating").Get("list").GetIndex(0)
-		assert.Equal(t, "[CR_REDACTED:v:weird%3Aname%5Dthing]", v.Get("query").MustString())
-		assert.Equal(t, "[CR_REDACTED:v:weird%3Aname%5Dthing]", v.Get("definition").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:weird%3Aname%5Dthing]", v.Get("query").MustString())
+		assert.Equal(t, "[MFE_REDACTED:v:weird%3Aname%5Dthing]", v.Get("definition").MustString())
 	})
 }

--- a/pkg/api/dashboard_mfe_mask_test.go
+++ b/pkg/api/dashboard_mfe_mask_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,12 +36,20 @@ func TestIsCodeRabbitMFE(t *testing.T) {
 	}
 
 	t.Run("unset", func(t *testing.T) {
-		// t.Setenv only restores; we want to test the missing-key path explicitly.
-		// The "" case above already sets it to empty (still present), so verify
-		// the LookupEnv-not-ok path by relying on the default test environment
-		// where the var is not set.
-		// (No-op sanity assertion — the value above covers the truthy parsing.)
-		assert.False(t, isCodeRabbitMFE() && false)
+		// Exercise the LookupEnv-not-ok path explicitly: clear the env var,
+		// remember whether the test environment had it set, and restore that
+		// state via t.Cleanup so we don't leak the change to other subtests.
+		old, existed := os.LookupEnv(crMFEEnvVar)
+		require.NoError(t, os.Unsetenv(crMFEEnvVar))
+		t.Cleanup(func() {
+			if existed {
+				require.NoError(t, os.Setenv(crMFEEnvVar, old))
+			} else {
+				require.NoError(t, os.Unsetenv(crMFEEnvVar))
+			}
+		})
+
+		assert.False(t, isCodeRabbitMFE())
 	})
 }
 
@@ -201,5 +210,44 @@ func TestMaskDashboardQueriesForMFE(t *testing.T) {
 
 	t.Run("nil dashboard is a no-op", func(t *testing.T) {
 		assert.NotPanics(t, func() { maskDashboardQueriesForMFE(nil) })
+	})
+
+	t.Run("URL-encodes delimiter characters in refId and variable name", func(t *testing.T) {
+		// Refs / variable names CAN technically include `:` or `]` — those are
+		// our structural delimiters, so the mask helpers must URL-escape them
+		// before concatenation. Otherwise the proxy parser can no longer
+		// unambiguously recover the original key.
+		raw := []byte(`{
+			"panels": [
+				{
+					"id": 7,
+					"type": "stat",
+					"targets": [
+						{"refId": "A:B]C", "rawSql": "SELECT 1"}
+					]
+				}
+			],
+			"templating": {
+				"list": [
+					{
+						"name": "weird:name]thing",
+						"type": "query",
+						"query": "SELECT 1",
+						"definition": "SELECT 1"
+					}
+				]
+			}
+		}`)
+		data, err := simplejson.NewJson(raw)
+		require.NoError(t, err)
+
+		maskDashboardQueriesForMFE(data)
+
+		panelMask := data.Get("panels").GetIndex(0).Get("targets").GetIndex(0).Get("rawSql").MustString()
+		assert.Equal(t, "[CR_REDACTED:p:7:A%3AB%5DC]", panelMask)
+
+		v := data.Get("templating").Get("list").GetIndex(0)
+		assert.Equal(t, "[CR_REDACTED:v:weird%3Aname%5Dthing]", v.Get("query").MustString())
+		assert.Equal(t, "[CR_REDACTED:v:weird%3Aname%5Dthing]", v.Get("definition").MustString())
 	})
 }

--- a/pkg/api/ds_query.go
+++ b/pkg/api/ds_query.go
@@ -80,6 +80,15 @@ func (hs *HTTPServer) QueryMetricsV2(c *contextmodel.ReqContext) response.Respon
 	if err != nil {
 		return hs.handleQueryMetricsError(err)
 	}
+	// When running as the CodeRabbit microfrontend, scrub the
+	// executed-query text the upstream datasource stamps on each frame.
+	// We masked the same text out of the dashboard JSON on the way out
+	// (see maskDashboardQueriesForMFE), and the resolved query — fully
+	// interpolated with template variables — must not leak back through
+	// the /api/ds/query response that powers the Query Inspector.
+	if isCodeRabbitMFE() {
+		maskExecutedQueriesForMFE(resp)
+	}
 	return hs.toJsonStreamingResponse(c.Req.Context(), resp)
 }
 

--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
@@ -359,4 +362,86 @@ func (f *fakePluginBackend) QueryData(ctx context.Context, req *backend.QueryDat
 
 func (f *fakePluginBackend) IsDecommissioned() bool {
 	return false
+}
+
+// TestAPIEndpoint_Metrics_QueryMetricsV2_MFEMasksExecutedQuery exercises the
+// /api/ds/query handler end-to-end with a fake plugin that stamps the
+// executed query string onto the response frame. When GF_MFE is set, the
+// handler must blank `frame.meta.executedQueryString` so the Query Inspector
+// (which reads exactly this field) cannot surface the resolved SQL/expr text
+// to the browser. When GF_MFE is unset, the field must pass through
+// untouched so non-MFE Grafana deployments are unaffected.
+func TestAPIEndpoint_Metrics_QueryMetricsV2_MFEMasksExecutedQuery(t *testing.T) {
+	const executedQuery = "SELECT id FROM tenants WHERE org_id = 'abc'"
+
+	setupServer := func(t *testing.T) *webtest.Server {
+		cfg := setting.NewCfg()
+		qds := query.ProvideService(
+			cfg,
+			nil,
+			nil,
+			&fakePluginRequestValidator{},
+			&fakePluginClient{
+				QueryDataHandlerFunc: func(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+					frame := &data.Frame{
+						Name:  "series",
+						RefID: "A",
+						Fields: []*data.Field{
+							data.NewField("v", nil, []float64{1, 2, 3}),
+						},
+						Meta: &data.FrameMeta{ExecutedQueryString: executedQuery},
+					}
+					return &backend.QueryDataResponse{
+						Responses: backend.Responses{
+							"A": backend.DataResponse{Frames: data.Frames{frame}},
+						},
+					}, nil
+				},
+			},
+			plugincontext.ProvideService(cfg, localcache.ProvideService(), &pluginstore.FakePluginStore{
+				PluginList: []pluginstore.Plugin{
+					{JSONData: plugins.JSONData{ID: "grafana"}},
+				},
+			}, &fakeDatasources.FakeCacheService{}, &fakeDatasources.FakeDataSourceService{},
+				pluginSettings.ProvideService(dbtest.NewFakeDB(), secretstest.NewFakeSecretsService()),
+				pluginconfig.NewFakePluginRequestConfigProvider()),
+		)
+		return SetupAPITestServer(t, func(hs *HTTPServer) {
+			hs.queryDataService = qds
+			hs.QuotaService = quotatest.New(false, nil)
+		})
+	}
+
+	doRequest := func(t *testing.T, srv *webtest.Server) []byte {
+		req := srv.NewPostRequest("/api/ds/query", strings.NewReader(reqValid))
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			UserID: 1, OrgID: 1,
+			Permissions: map[int64]map[string][]string{1: {datasources.ActionQuery: []string{datasources.ScopeAll}}},
+		})
+		resp, err := srv.SendJSON(req)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, resp.Body.Close()) }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return body
+	}
+
+	t.Run("GF_MFE=1 blanks executedQueryString on every frame", func(t *testing.T) {
+		t.Setenv(mfeEnvVar, "1")
+		srv := setupServer(t)
+		body := doRequest(t, srv)
+
+		assert.NotContains(t, string(body), executedQuery, "executed query must not appear in response body")
+		assert.NotContains(t, string(body), "executedQueryString", "field should be omitted (omitempty) when blanked")
+	})
+
+	t.Run("without GF_MFE the executedQueryString passes through unchanged", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv(mfeEnvVar))
+		srv := setupServer(t)
+		body := doRequest(t, srv)
+
+		assert.Contains(t, string(body), executedQuery, "non-MFE responses must include executed query")
+		assert.Contains(t, string(body), "executedQueryString")
+	})
 }

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -645,7 +645,7 @@ export const variableUpdated = (
 
     // When Grafana is running as the CodeRabbit microfrontend the backend
     // masks every panel's rawSql to a structural key like
-    // `[CR_REDACTED:p:<panelId>:<refId>]`. The dependency graph in
+    // `[MFE_REDACTED:p:<panelId>:<refId>]`. The dependency graph in
     // `getPanelVars` keys off `${var}` references inside each panel's JSON
     // and so sees zero affected panels for any variable change, breaking
     // the dashboard refresh. Fall back to `refreshAll: true` in this mode

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -643,8 +643,18 @@ export const variableUpdated = (
     const panels = state.dashboard?.getModel()?.panels ?? [];
     const panelVars = getPanelVars(panels);
 
+    // When Grafana is running as the CodeRabbit microfrontend the backend
+    // masks every panel's rawSql to a structural key like
+    // `[CR_REDACTED:p:<panelId>:<refId>]`. The dependency graph in
+    // `getPanelVars` keys off `${var}` references inside each panel's JSON
+    // and so sees zero affected panels for any variable change, breaking
+    // the dashboard refresh. Fall back to `refreshAll: true` in this mode
+    // so every panel re-renders on every variable change — same treatment
+    // as ad-hoc variables.
+    const isFnDashboard =
+      typeof window !== 'undefined' && (window as any).__FNDashboard__ === true;
     const event: VariablesChangedEvent =
-      variableInState.type === 'adhoc'
+      variableInState.type === 'adhoc' || isFnDashboard
         ? { refreshAll: true, panelIds: [] } // for adhoc variables we don't know which panels that will be impacted
         : {
             refreshAll: false,

--- a/public/app/features/variables/state/actions.ts
+++ b/public/app/features/variables/state/actions.ts
@@ -652,7 +652,7 @@ export const variableUpdated = (
     // so every panel re-renders on every variable change — same treatment
     // as ad-hoc variables.
     const isFnDashboard =
-      typeof window !== 'undefined' && (window as any).__FNDashboard__ === true;
+      typeof window !== 'undefined' && window.__FNDashboard__ === true;
     const event: VariablesChangedEvent =
       variableInState.type === 'adhoc' || isFnDashboard
         ? { refreshAll: true, panelIds: [] } // for adhoc variables we don't know which panels that will be impacted

--- a/public/app/store/configureMfeStore.ts
+++ b/public/app/store/configureMfeStore.ts
@@ -84,6 +84,13 @@ const reducers: SliceCaseReducers<MfeGlobalState> = {
     });
 
     state.renderingDashboardUID = action.payload;
+    // Mirror onto window so non-React code in `packages/grafana-runtime`
+    // (e.g. DataSourceWithBackend) can read the current dashboard UID when
+    // attaching it to FN-shaped /api/ds/query bodies for templating-variable
+    // queries (which Grafana dispatches without `request.dashboardUID`).
+    if (typeof window !== 'undefined') {
+      window.__FNDashboardRenderingUID__ = action.payload || undefined;
+    }
   },
 
   updateMfeMode: (state, action: PayloadAction<GrafanaThemeType.Light | GrafanaThemeType.Dark>) => {

--- a/public/app/store/configureMfeStore.ts
+++ b/public/app/store/configureMfeStore.ts
@@ -40,6 +40,13 @@ const reducers: SliceCaseReducers<MfeGlobalState> = {
     setGrafanaStore(state, uid);
     const fnState = state.dashboards[uid];
     state.FNDashboard = true;
+    // Expose the FNDashboard flag on `window` so that non-React code in
+    // `packages/grafana-runtime` (e.g. DataSourceWithBackend) can detect when
+    // Grafana is running as a CodeRabbit microfrontend without importing the
+    // app store (which would create a circular dependency).
+    if (typeof window !== 'undefined') {
+      window.__FNDashboard__ = true;
+    }
 
     if (!fnState) {
       state.dashboards = {

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -14,6 +14,14 @@ export declare global {
      * raw SQL/queries are not exposed from the frontend.
      */
     __FNDashboard__?: boolean;
+    /**
+     * The UID of the dashboard currently being rendered as the CodeRabbit
+     * microfrontend. Mirrored from the MFE store so that non-React code in
+     * `packages/grafana-runtime` can attach it to FN-shaped `/api/ds/query`
+     * bodies (panel queries already carry `request.dashboardUID`, but
+     * templating-variable queries are dispatched without it).
+     */
+    __FNDashboardRenderingUID__?: string;
     System: typeof System;
   }
 

--- a/public/app/types/window.d.ts
+++ b/public/app/types/window.d.ts
@@ -8,6 +8,12 @@ export declare global {
     nonce: string | undefined;
     __POWERED_BY_QIANKUN__: boolean;
     __INJECTED_PUBLIC_PATH_BY_QIANKUN__: string;
+    /**
+     * Set to `true` when Grafana is running as a CodeRabbit microfrontend (FNDashboard).
+     * Used by `DataSourceWithBackend` to alter the `/api/ds/query` POST body so that
+     * raw SQL/queries are not exposed from the frontend.
+     */
+    __FNDashboard__?: boolean;
     System: typeof System;
   }
 


### PR DESCRIPTION
## Summary

Two coordinated changes that remove raw datasource queries (SQL, PromQL, …) from the wire when Grafana is embedded as the CodeRabbit microfrontend (FNDashboard / CR MFE).

| # | Layer | What it does | Toggle |
|---|---|---|---|
| 1 | **Frontend** (`packages/grafana-runtime`) | Rewrites the `/api/ds/query` POST body to `{ dashboardUID, panelId, variables, filters, from, to }` instead of `{ queries, from, to }`. The backend resolves the saved query server-side. | `window.__FNDashboard__` (set by the MFE store) |
| 2 | **Backend** (`pkg/api`) | On `GET /api/dashboards/uid/{uid}`, walks the dashboard JSON and replaces known raw-query fields on every panel target with `"[REDACTED]"`. Recurses into row panels. | `GF_CR_MFE` env var (`1` / `true` / `yes` / `on`) |

Together these prevent raw datasource queries from ever reaching the browser when Grafana is embedded inside CodeRabbit, without changing standalone Grafana behaviour.

---

## Commit 1 — frontend: strip raw SQL from `/api/ds/query` body

`DataSourceWithBackend.query` in `packages/grafana-runtime` previously built a body of the form

```jsonc
{ "queries": [ { "rawSql": "…", "datasource": …, … } ], "from": "…", "to": "…" }
```

When `window.__FNDashboard__ === true` it now builds

```jsonc
{
  "dashboardUID": "<uid>",
  "panelId": <number>,
  "variables": { "<name>": "<value>", … },     // extracted from request.scopedVars
  "filters":   [ { key, operator, value }, … ], // ad-hoc filters
  "from": "<ms>",
  "to":   "<ms>"
}
```

### Why a window flag

`packages/grafana-runtime` cannot import from `public/app/*` (would create a cycle). Instead the existing MFE reducer (`public/app/store/configureMfeStore.ts`) mirrors its `state.FNDashboard = true` onto `window.__FNDashboard__`. The typing for the new window key lives in `public/app/types/window.d.ts`, which `packages/grafana-runtime/tsconfig.json` already pulls in.

### Files

- `packages/grafana-runtime/src/utils/DataSourceWithBackend.ts`
- `packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts` *(2 new unit tests)*
- `public/app/store/configureMfeStore.ts`
- `public/app/types/window.d.ts`

---

## Commit 2 — backend: redact queries from dashboard JSON when `GF_CR_MFE` is set

`GET /api/dashboards/uid/{uid}` (`hs.GetDashboard`) previously returned the dashboard JSON verbatim — every panel target included its raw `rawSql` / `expr` / `query` / `rawQuery` / `queryText` / `target` (graphite) string. When `GF_CR_MFE` is truthy, those string fields are now replaced with `"[REDACTED]"`. Everything else (panel layout, target metadata such as `refId` / `datasource` / `hide` / `format`, dashboard variables, …) is preserved so the frontend can still render the layout.

### Implementation notes

- The check follows the existing `GF_CR_*` env-var convention used elsewhere in the codebase (e.g. `GF_CR_POSTGRES_URL`, `GF_CR_RENDERER_AUTH_TOKEN_JWT_SECRET`).
- Recurses into row panels (which carry their children under a nested `panels` array).
- Only **string-valued** fields are masked, so e.g. influxdb's `rawQuery` boolean toggle keeps its type.
- The redaction lives in a separate file (`dashboard_mfe_mask.go`) so it's easy to extend with more field names if more datasource types are added later.

### Files

- `pkg/api/dashboard.go` — calls the helper in `GetDashboard` right after `dash.Data.Set("version", …)`.
- `pkg/api/dashboard_mfe_mask.go` — new helper + env-var detection.
- `pkg/api/dashboard_mfe_mask_test.go` — unit tests.

---

## Verification

| Command | Scope | Result |
|---|---|---|
| `yarn jest packages/grafana-runtime/src/utils/DataSourceWithBackend.test.ts --no-coverage` | frontend body rewrite | ✅ 15/15 pass (2 new) |
| `cd packages/grafana-runtime && yarn typecheck` | frontend types | ✅ no errors |
| `npx eslint <modified TS files>` | frontend lint | ✅ no errors |
| `go build ./pkg/api/...` | backend compile | ✅ |
| `go vet ./pkg/api/...` | backend static check | ✅ |
| `go test ./pkg/api/ -run "TestIsCodeRabbitMFE\|TestMaskDashboardQueriesForMFE" -count=1 -v` | new backend tests | ✅ 17/17 pass |
| `go test ./pkg/api/ -run "TestHTTPServer_GetDashboard_AccessControl\|TestDashboardAPIEndpoint" -count=1` | existing GetDashboard handler tests | ✅ |

### Pre-existing issues (NOT caused by this PR)

- Repository-wide `yarn typecheck` reports many errors inside `public/app/plugins/panel/volkovlabs-table-panel/**` — present on the base branch already, none of the modified files in this PR contribute new errors.
- `go test ./pkg/api/ -run TestDashboardSnapshotAPIEndpoint_singleSnapshot` panics with `no guardian factory implementation provided` — verified to also fail on the base branch with our changes stashed, so it is a pre-existing unrelated issue.

---

## Roll-out / env config

Self-hosted operators running Grafana as the CodeRabbit MFE should set:

```
GF_CR_MFE=1
```

on the Grafana backend process. The frontend half activates automatically when the MFE store enters dashboard mode.

## Assumptions

- `variables` (frontend body) is built from `request.scopedVars` by extracting each `ScopedVar.value`.
- `filters` (frontend body) is forwarded verbatim from `request.filters`, defaulting to `[]`.
- The masked frontend field list — `rawSql`, `expr`, `query`, `rawQuery`, `queryText`, `target` — covers the built-in Grafana datasources. If new datasource types are introduced, add their raw-query field to `crMaskedQueryFields` in `pkg/api/dashboard_mfe_mask.go`.
- The window flag is not unset on tear-down — once a host enters MFE mode it stays there for the SPA lifetime, matching the existing `state.FNDashboard` behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FNDashboard (microfrontend) support to enrich datasource query requests with FN context (templating variables + dashboard UID) without exposing raw query text.
  * Extended microfrontend masking to redact dashboard query fields and to scrub executed-query strings in `/api/ds/query` responses.
* **Bug Fixes**
  * Improved dashboard UID fallback across request, rendering UID, and URL path.
  * Ensured variable updates trigger full refresh appropriately in FNDashboard mode.
* **Tests**
  * Expanded unit and end-to-end coverage for FN request shaping, redaction/masking, and edge cases (including unset/nil/empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->