### PR TITLE
feat(mfe): gracefully fall back to a proxy stub datasource under FNDashboard

### DIFF
--- a/public/app/features/plugins/datasource_srv.ts
+++ b/public/app/features/plugins/datasource_srv.ts
@@ -2,13 +2,16 @@ import {
   AppEvents,
   DataSourceApi,
   DataSourceInstanceSettings,
+  DataSourcePluginMeta,
   DataSourceRef,
   DataSourceSelectItem,
+  PluginType,
   ScopedVars,
   matchPluginId,
 } from '@grafana/data';
 import {
   DataSourceSrv as DataSourceService,
+  DataSourceWithBackend,
   getBackendSrv,
   GetDataSourceListFilters,
   getDataSourceSrv as getDataSourceService,
@@ -152,6 +155,23 @@ export class DatasourceSrv implements DataSourceService {
     // find the metadata
     const instanceSettings = this.getInstanceSettings(key);
     if (!instanceSettings) {
+      // When Grafana is running as the CodeRabbit microfrontend the
+      // actual datasource plugins are not provisioned inside this
+      // instance — every SQL / query call is forwarded to
+      // `coderabbitHandler` which resolves it against the shipped
+      // dashboard JSON and executes it against the real backend
+      // (BigQuery). Rejecting here would fail every panel and every
+      // variable dropdown before the request ever reaches the proxy.
+      // Fall back to a stub that mirrors the reference name/UID and
+      // whose `query()` posts to `/api/ds/query` — the endpoint the
+      // proxy already intercepts — so the flow completes without a
+      // real datasource registration.
+      if (isFnDashboardEnabled()) {
+        const stub = createFnDashboardStubDatasource(key);
+        this.datasources[key] = stub;
+        this.datasources[stub.uid] = stub;
+        return stub;
+      }
       return Promise.reject({ message: `Datasource ${key} was not found` });
     }
 
@@ -194,6 +214,17 @@ export class DatasourceSrv implements DataSourceService {
     } catch (err) {
       if (err instanceof Error) {
         appEvents.emit(AppEvents.alertError, [instanceSettings.name + ' plugin failed', err.toString()]);
+      }
+      // Same rationale as above: in the microfrontend the plugin
+      // module may fail to load (no plugin bundle is shipped for the
+      // real datasource type). Return a stub built off the settings
+      // we already resolved so the caller can still submit the query
+      // to `/api/ds/query`.
+      if (isFnDashboardEnabled()) {
+        const stub = createFnDashboardStubDatasource(key, instanceSettings);
+        this.datasources[key] = stub;
+        this.datasources[stub.uid] = stub;
+        return stub;
       }
       return Promise.reject({ message: `Datasource: ${key} was not found` });
     }
@@ -368,3 +399,88 @@ export function variableInterpolation<T>(value: T | T[]) {
 export const getDatasourceSrv = (): DatasourceSrv => {
   return getDataSourceService() as DatasourceSrv;
 };
+
+/**
+ * True when Grafana is running as the CodeRabbit microfrontend.
+ *
+ * The MFE store mirrors the `fnGlobalState.FNDashboard` Redux slice
+ * onto `window.__FNDashboard__` at dispatch time (see
+ * `store/configureMfeStore.ts`) precisely so that low-level modules
+ * imported during app bootstrap can consult the flag without pulling
+ * in `app/store/store` — importing the store here would create a
+ * circular initialisation with `configureStore` and break every
+ * dashboard-scene test that transitively loads this file.
+ *
+ * When the flag is true, every `/api/ds/query` request is routed
+ * through the CodeRabbit backend proxy (`coderabbitHandler`), which
+ * resolves the panel/variable SQL from the shipped dashboard JSON and
+ * executes it against BigQuery. Real datasource plugins are not
+ * provisioned inside the embedded Grafana, so callers should treat a
+ * missing datasource as a proxy-only path instead of a hard error.
+ */
+function isFnDashboardEnabled(): boolean {
+  return typeof window !== 'undefined' && window.__FNDashboard__ === true;
+}
+
+/**
+ * Build a fake `DataSourceApi` for the microfrontend flow.
+ *
+ * The stub inherits from `DataSourceWithBackend`, which implements
+ * `query()` by POSTing the incoming `DataQueryRequest` to
+ * `/api/ds/query`. That endpoint is intercepted by the CodeRabbit
+ * proxy, so the stub's targets never need to reach a real datasource
+ * plugin — the proxy resolves the SQL from the dashboard JSON and
+ * executes it. `testDatasource()` returns a passing status because
+ * there is nothing meaningful to health-check on this side of the
+ * proxy.
+ *
+ * If `instanceSettings` are supplied (plugin-load failure path) the
+ * stub reuses them so its `type` / `meta` remain accurate; otherwise
+ * we synthesise a minimal `DataSourceInstanceSettings` using the
+ * caller's name/UID.
+ */
+function createFnDashboardStubDatasource(
+  key: string,
+  instanceSettings?: DataSourceInstanceSettings
+): DataSourceApi {
+  const settings = instanceSettings ?? synthesiseFnDashboardStubSettings(key);
+  return new FnDashboardStubDatasource(settings);
+}
+
+function synthesiseFnDashboardStubSettings(key: string): DataSourceInstanceSettings {
+  const meta: DataSourcePluginMeta = {
+    id: 'coderabbit-fn-dashboard-stub',
+    name: 'CodeRabbit MFE stub',
+    type: PluginType.datasource,
+    info: {
+      author: { name: 'CodeRabbit' },
+      description: 'Stub datasource used when Grafana runs as the CodeRabbit microfrontend.',
+      links: [],
+      logos: { small: '', large: '' },
+      screenshots: [],
+      updated: '',
+      version: '',
+    },
+    module: '',
+    baseUrl: '',
+  };
+  return {
+    id: 0,
+    uid: key,
+    type: meta.id,
+    name: key,
+    meta,
+    jsonData: {},
+    readOnly: true,
+    access: 'proxy',
+  };
+}
+
+class FnDashboardStubDatasource extends DataSourceWithBackend {
+  constructor(instanceSettings: DataSourceInstanceSettings) {
+    super(instanceSettings);
+  }
+  async testDatasource() {
+    return { status: 'success' as const, message: 'CodeRabbit MFE stub datasource — queries are proxied.' };
+  }
+}

--- a/public/app/features/variables/query/queryRunners.ts
+++ b/public/app/features/variables/query/queryRunners.ts
@@ -146,13 +146,85 @@ class CustomQueryRunner implements QueryRunner {
     throw new Error("Couldn't create a target with supplied arguments.");
   }
 
-  runRequest({ datasource, runRequest }: RunnerArgs, request: DataQueryRequest) {
+  runRequest({ datasource, variable, runRequest }: RunnerArgs, request: DataQueryRequest) {
     if (!hasCustomVariableSupport(datasource)) {
+      // Under the CodeRabbit microfrontend the datasource may be a
+      // stub that has no `variables` block because the query is
+      // resolved by the backend proxy. Rather than swallow the request
+      // with an empty result — which leaves variable dropdowns empty
+      // and blocks the rest of the flow — pass the request through
+      // unchanged so it still reaches `/api/ds/query`.
+      if (isFnDashboardEnabled()) {
+        return runRequest(datasource, stampVariableRefId(request, variable));
+      }
       return getEmptyMetricFindValueObservable();
     }
 
-    return runRequest(datasource, request, datasource.variables.query.bind(datasource.variables));
+    return runRequest(
+      datasource,
+      stampVariableRefId(request, variable),
+      datasource.variables.query.bind(datasource.variables)
+    );
   }
+}
+
+/**
+ * Stamp `refId = variable.name` onto every target of a variable's
+ * metric-find query when Grafana runs as the CodeRabbit microfrontend.
+ *
+ * Upstream Grafana leaves it to each datasource plugin to pick a refId
+ * for variable queries. The `grafana-bigquery-datasource` plugin, for
+ * example, uses `lodash.uniqueId('tempVar')` — a globally-incrementing
+ * counter (`tempVar1`, `tempVar2`, ...) that has no relation to the
+ * templating variable it describes. Downstream consumers of the
+ * request (the CodeRabbit request interceptor and the backend proxy's
+ * dashboard-query resolver) key their per-variable state off the
+ * refId, so a counter-based refId prevents both caching and reliable
+ * variable-name mapping.
+ *
+ * Using the variable name as the refId keeps the request self-
+ * describing without changing behaviour for upstream Grafana users —
+ * the stamp is only applied when the microfrontend flag is set.
+ */
+function stampVariableRefId(request: DataQueryRequest, variable?: QueryVariableModel): DataQueryRequest {
+  if (!isFnDashboardEnabled() || !variable?.name || !Array.isArray(request.targets)) {
+    return request;
+  }
+  return {
+    ...request,
+    targets: request.targets.map((t) => {
+      // Shipped CodeRabbit dashboards can store a variable's query as a
+      // bare string. Wrap those into a minimal `DataQuery` so the
+      // plugin's own `{ ...q, refId: q.refId || uniqueId(...) }` path
+      // has a real object to spread and picks up our refId.
+      if (typeof t === 'string') {
+        return { rawSql: t, refId: variable.name } as unknown as DataQuery;
+      }
+      if (t === null || typeof t !== 'object') {
+        return t;
+      }
+      const existing = (t as { refId?: unknown }).refId;
+      if (typeof existing === 'string' && existing.length > 0) {
+        return t;
+      }
+      return { ...t, refId: variable.name };
+    }),
+  };
+}
+
+/**
+ * True when Grafana is running as the CodeRabbit microfrontend.
+ *
+ * The MFE store mirrors `fnGlobalState.FNDashboard` onto
+ * `window.__FNDashboard__` for exactly this consumer pattern —
+ * importing `app/store/store` from a module that participates in
+ * variable-query resolution would drag in the whole store graph on
+ * every test that mounts a template variable and would create a
+ * bootstrap cycle. See the mirror site in
+ * `public/app/store/configureMfeStore.ts` for the write path.
+ */
+function isFnDashboardEnabled(): boolean {
+  return typeof window !== 'undefined' && window.__FNDashboard__ === true;
 }
 
 export const variableDummyRefId = 'variable-query';


### PR DESCRIPTION
## Summary

Two related fixes so the CodeRabbit microfrontend (`FNDashboard` mode) can render dashboards even though the embedded Grafana has no real datasource plugins provisioned — every `/api/ds/query` is proxied to `coderabbitHandler`, which resolves the SQL from the shipped dashboard JSON and executes it against BigQuery.

Before this change the embedded Grafana would reject with `Datasource <uid> was not found` the moment a panel tried to look up its datasource, so the whole render aborted before the request ever reached the proxy.

## What changed

### `public/app/features/plugins/datasource_srv.ts`

- `loadDatasource` no longer rejects on missing settings or plugin-load failure when `fnGlobalState.FNDashboard === true`.
- Instead it returns a synthesised stub `DataSourceApi` that extends `DataSourceWithBackend`, whose inherited `query()` posts to `/api/ds/query` — the endpoint the CodeRabbit proxy already intercepts. `testDatasource()` returns a passing status (nothing to health-check on this side of the proxy).
- The stub is cached like any other datasource, so repeated `get()` calls hit the same instance.
- Behaviour outside FNDashboard is unchanged: both rejection paths still throw exactly as before, so no upstream Grafana consumer sees a different failure mode.

### `public/app/features/variables/query/queryRunners.ts::CustomQueryRunner`

- If `hasCustomVariableSupport(datasource)` is false (which the new stub is), forward the request through `runRequest(datasource, ...)` under FNDashboard instead of swallowing it with an empty result. Swallowing here leaves variable dropdowns empty; the proxy handles the request end-to-end.
- Stamp `refId = variable.name` onto every target of the metric-find query under FNDashboard, in a new `stampVariableRefId` helper shared by both the stub path and the plugin path.
  - Upstream Grafana leaves refId selection to each datasource plugin. The `grafana-bigquery-datasource` plugin uses `lodash.uniqueId('tempVar')` — a globally-incrementing counter (`tempVar1`, `tempVar2`, …) with no relation to the templating variable it describes.
  - Downstream consumers (the CodeRabbit request interceptor's response cache and the proxy's `dashboard-query-resolver::templateVarByTempRefId`) key their per-variable state off the refId, so a counter-based refId prevents both caching and reliable variable-name mapping.
  - Only fires when the microfrontend flag is set — upstream Grafana users continue to see the plugin-generated refIds.

## How the FNDashboard flag is read

Both files consult `window.__FNDashboard__`, which is the mirror `store/configureMfeStore.ts` publishes from the `fnGlobalState.FNDashboard` Redux slice for exactly this consumer pattern. Importing `app/store/store` here would create a bootstrap cycle (`configureStore` → `DashboardModel` → `template_srv` → `variables/state/actions` → `queryRunners`) and break every dashboard-scene test that transitively loads these files.

## Verification

- `node_modules/.bin/tsc --noEmit`: 806 pre-existing errors in `volkovlabs-table-panel`, zero new errors in the touched files.
- `node_modules/.bin/jest --testPathPattern=datasource_srv`: **28 / 28** pass.
- `node_modules/.bin/eslint` on both touched files: clean.
- `queryRunners.test.ts` has a pre-existing test-setup failure (module resolution for `SceneDataLayerBase`) that reproduces on `origin/coderabbit_micro_frontend` without this patch, so it's unrelated.

## Files changed

- `public/app/features/plugins/datasource_srv.ts` (+116)
- `public/app/features/variables/query/queryRunners.ts` (+76, −2)

Total: 2 files changed, 190 insertions, 2 deletions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved compatibility for dashboards running without fully loaded data source plugins, allowing queries to continue in supported embedded/microfrontend setups.
* **Bug Fixes**
  * Variable queries now preserve their identifiers more reliably, improving query routing and results handling.
  * Datasource loading is more resilient when a plugin cannot be initialized, helping prevent query interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->